### PR TITLE
add example benchmark showing Dalli doesn't optimally handle large strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ profile.html
 ## Environment normalisation:
 /.bundle/
 /lib/bundler/man/
+dev.yml
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/inline'
+require 'json'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'dalli'
+  gem 'benchmark-ips'
+end
+
+require 'dalli'
+require 'benchmark/ips'
+
+##
+# StringSerializer is a serializer that avoids the overhead of Marshal or JSON.
+##
+class StringSerializer
+  def self.dump(value)
+    value
+  end
+
+  def self.load(value)
+    value
+  end
+end
+
+client = Dalli::Client.new('localhost', compress: false)
+json_client = Dalli::Client.new('localhost', serializer: JSON, compress: false)
+string_client = Dalli::Client.new('localhost', serializer: StringSerializer, compress: false)
+
+payload = 'B' * 1_000_000
+client.set('key', payload)
+json_client.set('json_key', payload)
+string_client.set('string_key', payload)
+Benchmark.ips do |x|
+  x.report('get 1MB MARSHAL') { client.get('key') }
+  x.report('get 1MB JSON') { json_client.get('json_key') }
+  x.report('get 1MB STRING') { string_client.get('string_key') }
+end

--- a/test/test_rack_session.rb
+++ b/test/test_rack_session.rb
@@ -114,7 +114,7 @@ describe Rack::Session::Dalli do
     res = Rack::MockRequest.new(rsd).get('/')
 
     assert_includes res['Set-Cookie'], "#{session_key}="
-    assert_equal '{"counter"=>1}', res.body
+    assert_equal '{"counter"=>1}', res.body.delete(' ')
   end
 
   it 'determines session from a cookie' do
@@ -123,8 +123,8 @@ describe Rack::Session::Dalli do
     res = req.get('/')
     cookie = res['Set-Cookie']
 
-    assert_equal '{"counter"=>2}', req.get('/', 'HTTP_COOKIE' => cookie).body
-    assert_equal '{"counter"=>3}', req.get('/', 'HTTP_COOKIE' => cookie).body
+    assert_equal '{"counter"=>2}', req.get('/', 'HTTP_COOKIE' => cookie).body.delete(' ')
+    assert_equal '{"counter"=>3}', req.get('/', 'HTTP_COOKIE' => cookie).body.delete(' ')
   end
 
   it 'determines session only from a cookie by default' do
@@ -133,8 +133,8 @@ describe Rack::Session::Dalli do
     res = req.get('/')
     sid = res['Set-Cookie'][session_match, 1]
 
-    assert_equal '{"counter"=>1}', req.get("/?rack.session=#{sid}").body
-    assert_equal '{"counter"=>1}', req.get("/?rack.session=#{sid}").body
+    assert_equal '{"counter"=>1}', req.get("/?rack.session=#{sid}").body.delete(' ')
+    assert_equal '{"counter"=>1}', req.get("/?rack.session=#{sid}").body.delete(' ')
   end
 
   it 'determines session from params' do
@@ -143,8 +143,8 @@ describe Rack::Session::Dalli do
     res = req.get('/')
     sid = res['Set-Cookie'][session_match, 1]
 
-    assert_equal '{"counter"=>2}', req.get("/?rack.session=#{sid}").body
-    assert_equal '{"counter"=>3}', req.get("/?rack.session=#{sid}").body
+    assert_equal '{"counter"=>2}', req.get("/?rack.session=#{sid}").body.delete(' ')
+    assert_equal '{"counter"=>3}', req.get("/?rack.session=#{sid}").body.delete(' ')
   end
 
   it 'survives nonexistant cookies' do
@@ -153,7 +153,7 @@ describe Rack::Session::Dalli do
     res = Rack::MockRequest.new(rsd)
                            .get('/', 'HTTP_COOKIE' => bad_cookie)
 
-    assert_equal '{"counter"=>1}', res.body
+    assert_equal '{"counter"=>1}', res.body.delete(' ')
     cookie = res['Set-Cookie'][session_match]
 
     refute_match(/#{bad_cookie}/, cookie)
@@ -173,32 +173,32 @@ describe Rack::Session::Dalli do
     rsd = Rack::Session::Dalli.new(incrementor, expire_after: 3)
     res = Rack::MockRequest.new(rsd).get('/')
 
-    assert_includes res.body, '"counter"=>1'
+    assert_includes res.body.delete(' '), '"counter"=>1'
     cookie = res['Set-Cookie']
     puts 'Sleeping to expire session' if $DEBUG
     sleep 4
     res = Rack::MockRequest.new(rsd).get('/', 'HTTP_COOKIE' => cookie)
 
     refute_equal cookie, res['Set-Cookie']
-    assert_includes res.body, '"counter"=>1'
+    assert_includes res.body.delete(' '), '"counter"=>1'
   end
 
   it 'maintains freshness of existing sessions' do
     rsd = Rack::Session::Dalli.new(incrementor, expire_after: 3)
     res = Rack::MockRequest.new(rsd).get('/')
 
-    assert_includes res.body, '"counter"=>1'
+    assert_includes res.body.delete(' '), '"counter"=>1'
     cookie = res['Set-Cookie']
     res = Rack::MockRequest.new(rsd).get('/', 'HTTP_COOKIE' => cookie)
 
     assert_equal cookie, res['Set-Cookie']
-    assert_includes res.body, '"counter"=>2'
+    assert_includes res.body.delete(' '), '"counter"=>2'
     puts 'Sleeping to expire session' if $DEBUG
     sleep 4
     res = Rack::MockRequest.new(rsd).get('/', 'HTTP_COOKIE' => cookie)
 
     refute_equal cookie, res['Set-Cookie']
-    assert_includes res.body, '"counter"=>1'
+    assert_includes res.body.delete(' '), '"counter"=>1'
   end
 
   it 'does not send the same session id if it did not change' do
@@ -208,17 +208,17 @@ describe Rack::Session::Dalli do
     res0 = req.get('/')
     cookie = res0['Set-Cookie'][session_match]
 
-    assert_equal '{"counter"=>1}', res0.body
+    assert_equal '{"counter"=>1}', res0.body.delete(' ')
 
     res1 = req.get('/', 'HTTP_COOKIE' => cookie)
 
     assert_nil res1['Set-Cookie']
-    assert_equal '{"counter"=>2}', res1.body
+    assert_equal '{"counter"=>2}', res1.body.delete(' ')
 
     res2 = req.get('/', 'HTTP_COOKIE' => cookie)
 
     assert_nil res2['Set-Cookie']
-    assert_equal '{"counter"=>3}', res2.body
+    assert_equal '{"counter"=>3}', res2.body.delete(' ')
   end
 
   it 'deletes cookies with :drop option' do
@@ -230,17 +230,17 @@ describe Rack::Session::Dalli do
     res1 = req.get('/')
     session = (cookie = res1['Set-Cookie'])[session_match]
 
-    assert_equal '{"counter"=>1}', res1.body
+    assert_equal '{"counter"=>1}', res1.body.delete(' ')
 
     res2 = dreq.get('/', 'HTTP_COOKIE' => cookie)
 
     assert_nil res2['Set-Cookie']
-    assert_equal '{"counter"=>2}', res2.body
+    assert_equal '{"counter"=>2}', res2.body.delete(' ')
 
     res3 = req.get('/', 'HTTP_COOKIE' => cookie)
 
     refute_equal session, res3['Set-Cookie'][session_match]
-    assert_equal '{"counter"=>1}', res3.body
+    assert_equal '{"counter"=>1}', res3.body.delete(' ')
   end
 
   it 'provides new session id with :renew option' do
@@ -252,23 +252,23 @@ describe Rack::Session::Dalli do
     res1 = req.get('/')
     session = (cookie = res1['Set-Cookie'])[session_match]
 
-    assert_equal '{"counter"=>1}', res1.body
+    assert_equal '{"counter"=>1}', res1.body.delete(' ')
 
     res2 = rreq.get('/', 'HTTP_COOKIE' => cookie)
     new_cookie = res2['Set-Cookie']
     new_session = new_cookie[session_match]
 
     refute_equal session, new_session
-    assert_equal '{"counter"=>2}', res2.body
+    assert_equal '{"counter"=>2}', res2.body.delete(' ')
 
     res3 = req.get('/', 'HTTP_COOKIE' => new_cookie)
 
-    assert_equal '{"counter"=>3}', res3.body
+    assert_equal '{"counter"=>3}', res3.body.delete(' ')
 
     # Old cookie was deleted
     res4 = req.get('/', 'HTTP_COOKIE' => cookie)
 
-    assert_equal '{"counter"=>1}', res4.body
+    assert_equal '{"counter"=>1}', res4.body.delete(' ')
   end
 
   it 'omits cookie with :defer option but still updates the state' do
@@ -281,15 +281,15 @@ describe Rack::Session::Dalli do
     res0 = dreq.get('/')
 
     assert_nil res0['Set-Cookie']
-    assert_equal '{"counter"=>1}', res0.body
+    assert_equal '{"counter"=>1}', res0.body.delete(' ')
 
     res0 = creq.get('/')
     res1 = dreq.get('/', 'HTTP_COOKIE' => res0['Set-Cookie'])
 
-    assert_equal '{"counter"=>2}', res1.body
+    assert_equal '{"counter"=>2}', res1.body.delete(' ')
     res2 = dreq.get('/', 'HTTP_COOKIE' => res0['Set-Cookie'])
 
-    assert_equal '{"counter"=>3}', res2.body
+    assert_equal '{"counter"=>3}', res2.body.delete(' ')
   end
 
   it 'omits cookie and state update with :skip option' do
@@ -302,15 +302,15 @@ describe Rack::Session::Dalli do
     res0 = sreq.get('/')
 
     assert_nil res0['Set-Cookie']
-    assert_equal '{"counter"=>1}', res0.body
+    assert_equal '{"counter"=>1}', res0.body.delete(' ')
 
     res0 = creq.get('/')
     res1 = sreq.get('/', 'HTTP_COOKIE' => res0['Set-Cookie'])
 
-    assert_equal '{"counter"=>2}', res1.body
+    assert_equal '{"counter"=>2}', res1.body.delete(' ')
     res2 = sreq.get('/', 'HTTP_COOKIE' => res0['Set-Cookie'])
 
-    assert_equal '{"counter"=>2}', res2.body
+    assert_equal '{"counter"=>2}', res2.body.delete(' ')
   end
 
   it 'updates deep hashes correctly' do
@@ -332,13 +332,13 @@ describe Rack::Session::Dalli do
     ses0 = JSON.parse(res0.body)
 
     refute_nil ses0
-    assert_equal '{"a"=>"b", "c"=>{"d"=>"e"}, "f"=>{"g"=>{"h"=>"i"}}, "test"=>true}', ses0.to_s
+    assert_equal '{"a"=>"b", "c"=>{"d"=>"e"}, "f"=>{"g"=>{"h"=>"i"}}, "test"=>true}'.delete(' '), ses0.to_s.delete(' ')
 
     res1 = req.get('/', 'HTTP_COOKIE' => cookie)
     ses1 = JSON.parse(res1.body)
 
     refute_nil ses1
-    assert_equal '{"a"=>"b", "c"=>{"d"=>"e"}, "f"=>{"g"=>{"h"=>"j"}}, "test"=>true}', ses1.to_s
+    assert_equal '{"a"=>"b", "c"=>{"d"=>"e"}, "f"=>{"g"=>{"h"=>"j"}}, "test"=>true}'.delete(' '), ses1.to_s.delete(' ')
 
     refute_equal ses0, ses1
   end


### PR DESCRIPTION
We will want to start adding some benchmarks as we modify the existing code or specifically target performance improvements. This PR starts with a very simple benchmark example, which we can build on.

OK, yeah there will definitely be some more performance to squeeze from dalli out of the box... Dalli still doesn't have the [string bypass](https://github.com/petergoldstein/dalli/pull/938/files), and even though Rails Active Support Cache handles serialization and compression, it looks like without minor modification Dali still tries to wrap with it's own serialization...

This benchmark shows a quick work around, but I think we could update the original PR and clean up the conflicts and tests so that all Rails users would get a performance boast out of the box and we wouldn't need to configure all of our apps. We have previously avoided this issue as our previous internal adapters did handle this large string bypass.

```
Warming up --------------------------------------
     get 1MB MARSHAL   168.000 i/100ms
        get 1MB JSON    59.000 i/100ms
      get 1MB STRING   225.000 i/100ms
Calculating -------------------------------------
     get 1MB MARSHAL      1.755k (± 5.1%) i/s  (569.80 μs/i) -      8.904k in   5.087145s
        get 1MB JSON    604.734 (± 2.0%) i/s    (1.65 ms/i) -      3.068k in   5.075365s
      get 1MB STRING      2.411k (± 5.6%) i/s  (414.74 μs/i) -     12.150k in   5.056508s
```