### PR TITLE
async proof of concept

### DIFF
--- a/bin/async
+++ b/bin/async
@@ -1,0 +1,160 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This helps benchmark current performance of Dalli
+# comparing sync vs async calls.
+#
+# This microbenchmark doens't show the real value of async as there is no other work occuring while IO is occuring
+# it shows the overhead of async vs sync. It also shows efficiency of async switching duirng IO.
+#
+# In real world async is useful when there is other work occuring and it should reduce latency.
+# For example when using puma, falcon, and async database clients which we have in SFR.
+#
+# * for small payloads on a fast local connection async will be slower, example 50K bytes local is ~20% slower
+# * as time spent on IO increases async will start to look better, and async will start to beat sync
+#   * as we increase payload size async will start to beat sync as there is more time spent on IO
+#   * as we increase latency (memcached over the network (run through toxiproxy to see this locally))
+#
+# run with:
+# bundle exec bin/async
+require 'bundler/inline'
+require 'json'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'dalli'
+  gem 'benchmark-ips'
+  gem 'async'
+  gem 'connection_pool'
+end
+
+require 'dalli'
+require 'benchmark/ips'
+require 'async'
+require 'connection_pool'
+
+##
+# StringSerializer is a serializer that avoids the overhead of Marshal or JSON.
+##
+class StringSerializer
+  def self.dump(value)
+    value
+  end
+
+  def self.load(value)
+    value
+  end
+end
+
+BENCH_TIME = (ENV['BENCH_TIME'] || 5).to_i
+BENCH_JOB  = ENV['BENCH_JOB'] || 'set'
+POOL_SIZE = (ENV['POOL_SIZE'] || 10).to_i
+PAYLOAD_SIZE = (ENV['PAYLOAD_SIZE'] || 50_000).to_i
+# setup toxiproxy to run locally, and pass in the port to use
+MEMCACHED_PORT = (ENV['MEMCACHED_PORT'] || 11211).to_i
+TERMINATOR = "\r\n"
+
+memcached_pool = ConnectionPool.new(size: 10, timeout: 1) do
+  Dalli::Client.new("localhost:#{MEMCACHED_PORT}", protocol: :meta, serializer: StringSerializer,compress: false)
+end
+meta_client = Dalli::Client.new("localhost:#{MEMCACHED_PORT}", protocol: :meta, serializer: StringSerializer, compress: false)
+payload_value = 'B' * PAYLOAD_SIZE
+
+puts "benchmarking async with #{POOL_SIZE} connections"
+
+# ensure the clients are all connected and working
+meta_client.set('meta_key', payload_value)
+# ensure we have basic data for the benchmarks and get calls
+pairs = {}
+100.times do |i|
+  pairs["multi_#{i}"] = payload_value
+end
+pairs.each do |key, value|
+  meta_client.set(key, value, 3600, raw: true)
+end
+
+###
+# GC Suite
+# benchmark without GC skewing things
+###
+class GCSuite
+  def warming(*)
+    run_gc
+  end
+
+  def running(*)
+    run_gc
+  end
+
+  def warmup_stats(*); end
+
+  def add_report(*); end
+
+  private
+
+  def run_gc
+    GC.enable
+    GC.start
+    GC.disable
+  end
+end
+suite = GCSuite.new
+
+def get_key(memcached_pool, key)
+	Sync do
+		return memcached_pool.with do |conn|
+      conn.get(key)
+    end
+	end
+end
+
+def async_get_all(memcached_pool, keys)
+	Sync do |parent|
+		keys.map do |key|
+			parent.async do
+				get_key(memcached_pool, key)
+			end
+		end.map(&:wait)
+	end
+end
+
+def async_set_all(memcached_pool, pairs)
+	Sync do |parent|
+		pairs.map do |key, value|
+			parent.async do
+				memcached_pool.with do |conn|
+					conn.set(key, value, 3600, raw: true)
+				end
+			end
+		end.map(&:wait)
+	end
+end
+
+case BENCH_JOB
+when 'get'
+  Benchmark.ips do |x|
+    x.config(warmup: 2, time: BENCH_TIME, suite: suite)
+    x.report('get 100 keys loop') do
+      pairs.keys.map do |key|
+        meta_client.get(key)
+      end
+    end
+    x.report('get 100 keys async') do
+      async_get_all(memcached_pool, pairs.keys)
+    end
+    x.compare!
+  end
+when 'set'
+  Benchmark.ips do |x|
+    x.config(warmup: 2, time: BENCH_TIME, suite: suite)
+    x.report('write 100 keys loop') do
+      pairs.each do |key, value|
+        meta_client.set(key, value, 3600, raw: true)
+      end
+    end
+    x.report('write 100 keys async') do
+      async_set_all(memcached_pool, pairs)
+    end
+    x.compare!
+  end
+end


### PR DESCRIPTION
We want to verify dalli works well with the async library and check some basic performance impacts... This is a small proof of concept to show how dalli can be used with async along with a connection pool to increase performance across multiple cache requests that could be in threads or fibers.

There is some overhead and a normal non async set of calls will win on very small and very fast calls... but as the IO increases either with payload size or by making remote network calls that have higher latency async shows how it can more efficiently balance the IO.

Async across toxiproxy with around 2X the latency of normal localhost, async easily out performing in this case

```
❯❯❯$ BENCH_JOB=get bundle exec bin/async                                                                                <bundler> [main]
benchmarking async with 10 connections
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
   get 100 keys loop     5.000 i/100ms
  get 100 keys async    11.000 i/100ms
Calculating -------------------------------------
   get 100 keys loop     72.508 (± 8.3%) i/s   (13.79 ms/i) -    360.000 in   5.036897s
  get 100 keys async    109.261 (±16.5%) i/s    (9.15 ms/i) -    528.000 in   5.020974s

Comparison:
  get 100 keys async:      109.3 i/s
   get 100 keys loop:       72.5 i/s - 1.51x  slower


~/projects/dalli                                                                                                              [13:48:34]
❯❯❯$ BENCH_JOB=set bundle exec bin/async                                                                                <bundler> [main]
benchmarking async with 10 connections
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
 write 100 keys loop     6.000 i/100ms
write 100 keys async    12.000 i/100ms
Calculating -------------------------------------
 write 100 keys loop     72.161 (± 4.2%) i/s   (13.86 ms/i) -    366.000 in   5.081488s
write 100 keys async    118.966 (±15.1%) i/s    (8.41 ms/i) -    564.000 in   5.013887s

Comparison:
write 100 keys async:      119.0 i/s
 write 100 keys loop:       72.2 i/s - 1.65x  slower
```

50k payload on fast localhost, holding nearly equal with a loop, showing some of the overhead involved in async:

```
❯❯❯$ BENCH_JOB=get bundle exec bin/async                                                                                <bundler> [main]
benchmarking async with 10 connections
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
   get 100 keys loop    13.000 i/100ms
  get 100 keys async    14.000 i/100ms
Calculating -------------------------------------
   get 100 keys loop    142.440 (± 5.6%) i/s    (7.02 ms/i) -    715.000 in   5.034559s
  get 100 keys async    128.682 (± 9.3%) i/s    (7.77 ms/i) -    644.000 in   5.046229s

Comparison:
   get 100 keys loop:      142.4 i/s
  get 100 keys async:      128.7 i/s - same-ish: difference falls within error


~/projects/dalli                                                                                                              [13:50:11]
❯❯❯$ BENCH_JOB=set bundle exec bin/async                                                                                <bundler> [main]
benchmarking async with 10 connections
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
 write 100 keys loop    14.000 i/100ms
write 100 keys async    14.000 i/100ms
Calculating -------------------------------------
 write 100 keys loop    151.000 (± 6.0%) i/s    (6.62 ms/i) -    756.000 in   5.021468s
write 100 keys async    137.135 (±14.6%) i/s    (7.29 ms/i) -    686.000 in   5.097228s

Comparison:
 write 100 keys loop:      151.0 i/s
write 100 keys async:      137.1 i/s - same-ish: difference falls within error
```