### PR TITLE
Fix optimized single server get multi

### DIFF
--- a/lib/dalli/key_manager.rb
+++ b/lib/dalli/key_manager.rb
@@ -70,6 +70,12 @@ module Dalli
       key.sub(namespace_regexp, '')
     end
 
+    def key_values_without_namespace(key_values)
+      return key_values if namespace.nil?
+
+      key_values.transform_keys! { |key| key_without_namespace(key) }
+    end
+
     def digest_class
       @digest_class ||= @key_options[:digest_class]
     end

--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -11,7 +11,9 @@ module Dalli
     end
 
     def optimized_for_single_server(keys)
-      @ring.servers.first.request(:read_multi_req, keys)
+      keys.map! { |a| @key_manager.validate_key(a.to_s) }
+      results = @ring.servers.first.request(:read_multi_req, keys)
+      @key_manager.key_values_without_namespace(results)
     rescue NetworkError => e
       Dalli.logger.debug { e.inspect }
       Dalli.logger.debug { 'bailing on pipelined gets because of timeout' }


### PR DESCRIPTION
We were not correctly transforming keys/values with the marshaller/key namespacing. This was causing some problems in other tests while trying to remove binary (since we skipped using this in binary mode).