### PR TITLE
Remove support for < ruby 3.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,6 @@ jobs:
           - head
           - '3.3'
           - '3.2'
-          - '3.1'
-          - '3.0'
-          - '2.7'
-          - jruby-9.4
         memcached-version: ['1.5.22', '1.6.23']
 
     steps:

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,6 +1,6 @@
 fix: false               # default: false
 parallel: true          # default: false
-ruby_version: 2.5.1     # default: RUBY_VERSION
+ruby_version: 3.3.0     # default: RUBY_VERSION
 default_ignores: false  # default: true
 
 ignore:                 # default: []

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -102,15 +102,14 @@ module Dalli
         # To check this we are using the fact that resolv-replace
         # aliases TCPSocket#initialize method to #original_resolv_initialize.
         # https://github.com/ruby/resolv-replace/blob/v0.1.1/lib/resolv-replace.rb#L21
-        if RUBY_VERSION >= '3.0' &&
-           !::TCPSocket.private_instance_methods.include?(:original_resolv_initialize)
-          sock = new(host, port, connect_timeout: options[:socket_timeout])
-          yield(sock)
-        else
+        if ::TCPSocket.private_instance_methods.include?(:original_resolv_initialize)
           Timeout.timeout(options[:socket_timeout]) do
             sock = new(host, port)
             yield(sock)
           end
+        else
+          sock = new(host, port, connect_timeout: options[:socket_timeout])
+          yield(sock)
         end
       end
 

--- a/test/integration/test_failover.rb
+++ b/test/integration/test_failover.rb
@@ -5,28 +5,24 @@ require_relative '../helper'
 describe 'failover' do
   MemcachedManager.supported_protocols.each do |p|
     describe "using the #{p} protocol" do
-      # Timeouts on JRuby work differently and aren't firing, meaning we're
-      # not testing the condition
-      unless defined? JRUBY_VERSION
-        describe 'timeouts' do
-          it 'not lead to corrupt sockets' do
-            memcached_persistent(p) do |dc|
-              value = { test: '123' }
-              begin
-                Timeout.timeout 0.01 do
-                  start_time = Time.now
-                  10_000.times do
-                    dc.set('test_123', value)
-                  end
-
-                  flunk("Did not timeout in #{Time.now - start_time}")
+      describe 'timeouts' do
+        it 'not lead to corrupt sockets' do
+          memcached_persistent(p) do |dc|
+            value = { test: '123' }
+            begin
+              Timeout.timeout 0.01 do
+                start_time = Time.now
+                10_000.times do
+                  dc.set('test_123', value)
                 end
-              rescue Timeout::Error
-                # Ignore expected timeout
-              end
 
-              assert_equal(value, dc.get('test_123'))
+                flunk("Did not timeout in #{Time.now - start_time}")
+              end
+            rescue Timeout::Error
+              # Ignore expected timeout
             end
+
+            assert_equal(value, dc.get('test_123'))
           end
         end
       end


### PR DESCRIPTION
Our new timeouts only work in > Ruby 3.2. Instead of adding if-statements everywhere, we are just going to drop support for old ruby versions. We might as well also remove support for jruby at this time.