### PR TITLE
Fix toxiproxy tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ Metrics/BlockLength:
 Style/Documentation:
   Exclude:
     - 'test/**/*'
+
+Metrics/MethodLength:
+  Max: 20

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -95,7 +95,6 @@ module Dalli
     # Fetch multiple keys efficiently.
     # If a block is given, yields key/value pairs one at a time.
     # Otherwise returns a hash of { 'key' => 'value', 'key2' => 'value1' }
-    # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
     def get_multi(*keys)
       keys.flatten!
@@ -113,7 +112,6 @@ module Dalli
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
 
     ##

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -24,7 +24,6 @@ module Dalli
       # * only supports single server
       # * only supports set at the moment
       # * doesn't support cas at the moment
-      # rubocop:disable Metrics/MethodLength
       def write_multi_storage_req(_mode, pairs, ttl = nil, _cas = nil, options = {})
         ttl = TtlSanitizer.sanitize(ttl) if ttl
         count = pairs.length
@@ -49,9 +48,7 @@ module Dalli
         end
         response_processor.meta_set_with_cas
       end
-      # rubocop:enable Metrics/MethodLength
 
-      # rubocop:disable Metrics/MethodLength
       def read_multi_req(keys)
         keys.each do |key|
           @connection_manager.write("mg #{key} v f k q\r\n")
@@ -71,7 +68,6 @@ module Dalli
         results
       end
 
-      # rubocop:enable Metrics/MethodLength
       # Retrieval Commands
       def get(key, options = nil)
         encoded_key, base64 = KeyRegularizer.encode(key)

--- a/lib/dalli/protocol/meta/request_formatter.rb
+++ b/lib/dalli/protocol/meta/request_formatter.rb
@@ -13,7 +13,6 @@ module Dalli
         # and introducing an intermediate object seems like overkill.
         #
         # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/ParameterLists
         # rubocop:disable Metrics/PerceivedComplexity
         def self.meta_get(key:, value: true, return_cas: false, ttl: nil, base64: false, quiet: false, meta_flags: nil)
@@ -63,7 +62,6 @@ module Dalli
           cmd + TERMINATOR
         end
         # rubocop:enable Metrics/CyclomaticComplexity
-        # rubocop:enable Metrics/MethodLength
         # rubocop:enable Metrics/ParameterLists
         # rubocop:enable Metrics/PerceivedComplexity
 
@@ -88,7 +86,6 @@ module Dalli
           cmd + TERMINATOR
         end
 
-        # rubocop:disable Metrics/MethodLength
         def self.mode_to_token(mode)
           case mode
           when :add
@@ -103,7 +100,6 @@ module Dalli
             'S'
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def self.cas_string(cas)
           cas = parse_to_64_bit_int(cas, nil)

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -113,7 +113,6 @@ module Dalli
         end
       end
 
-      # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/AbcSize
       def self.init_socket_options(sock, options)
         sock.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
@@ -134,7 +133,6 @@ module Dalli
           sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_SNDTIMEO, timeval)
         end
       end
-      # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize
 
       def self.wrapping_ssl_socket(tcp_socket, host, ssl_context)

--- a/test/helpers/memcached.rb
+++ b/test/helpers/memcached.rb
@@ -58,8 +58,14 @@ module Memcached
     # for the memcached process.
     ###
     # rubocop:disable Metrics/ParameterLists
-    def toxi_memcached_persistent(protocol = :binary, port = MemcachedManager::TOXIPROXY_UPSTREAM_PORT, args = '', client_options = {}, &)
-      raise "Toxiproxy does not support unix sockets" if port.to_i.zero?
+    def toxi_memcached_persistent(
+      protocol = :binary,
+      port = MemcachedManager::TOXIPROXY_UPSTREAM_PORT,
+      args = '',
+      client_options = {},
+      &
+    )
+      raise 'Toxiproxy does not support unix sockets' if port.to_i.zero?
 
       unless @toxy_configured
         Toxiproxy.populate([{
@@ -76,11 +82,7 @@ module Memcached
         "localhost:#{MemcachedManager::TOXIPROXY_MEMCACHED_PORT}",
         client_options.merge(protocol: protocol)
       )
-      if block_given?
-        yield dc, port
-      else
-        dc
-      end
+      yield dc, port
     end
     # rubocop:enable Metrics/ParameterLists
 

--- a/test/utils/memcached_manager.rb
+++ b/test/utils/memcached_manager.rb
@@ -49,7 +49,7 @@ module MemcachedManager
   end
 
   def self.start(port_or_socket, args)
-    raise "Do not re-use toxiproxy port for memcached" if port_or_socket == TOXIPROXY_MEMCACHED_PORT
+    raise 'Do not re-use toxiproxy port for memcached' if port_or_socket == TOXIPROXY_MEMCACHED_PORT
 
     cmd_with_args, key = cmd_with_args(port_or_socket, args)
     @running_pids[key] ||= begin


### PR DESCRIPTION
Our toxiproxy was being configured incorrectly.

We were creating a toxiproxy config, but instead of pointing the client that we created at the toxiproxy, we were pointing the client at the upstream memcached that we created.

This now creates a specific upstream memcached for toxiproxy, and also makes sure that we return a client that points at the toxiproxy.