### PR TITLE
Gracefully handle SERVER_ERROR

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -27,6 +27,9 @@ module Dalli
   # operation is not permitted in a multi block
   class NotPermittedMultiOpError < DalliError; end
 
+  # server error, raised when Memcached responds with a SERVER_ERROR
+  class ServerError < DalliError; end
+
   # Implements the NullObject pattern to store an application-defined value for 'Key not found' responses.
   class NilObject; end # rubocop:disable Lint/EmptyClass
   NOT_FOUND = NilObject.new

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -42,7 +42,7 @@ module Dalli
         rescue Dalli::MarshalError => e
           log_marshal_err(args.first, e)
           raise
-        rescue Dalli::DalliError
+        rescue Dalli::DalliError, Dalli::ServerError
           raise
         rescue StandardError => e
           log_unexpected_err(e)

--- a/lib/dalli/protocol/meta/response_processor.rb
+++ b/lib/dalli/protocol/meta/response_processor.rb
@@ -21,6 +21,7 @@ module Dalli
         STAT = 'STAT'
         VA = 'VA'
         VERSION = 'VERSION'
+        SERVER_ERROR = 'SERVER_ERROR'
 
         def initialize(io_source, value_marshaller)
           @io_source = io_source
@@ -179,9 +180,12 @@ module Dalli
 
         def error_on_unexpected!(expected_codes)
           tokens = next_line_to_tokens
-          raise Dalli::DalliError, "Response error: #{tokens.first}" unless expected_codes.include?(tokens.first)
 
-          tokens
+          return tokens if expected_codes.include?(tokens.first)
+
+          raise Dalli::ServerError if tokens.first == SERVER_ERROR
+
+          raise Dalli::DalliError, "Response error: #{tokens.first}"
         end
 
         def meta_flags_from_tokens(tokens)


### PR DESCRIPTION
`SERVER_ERROR` is a valid response via the Memcached text protocol: https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L172

It also states that if a server error is sent, it is the server's responsiblity to close the connection if it needs to, but the client should generally keep the connection open. This change does that for us, but still raises the error up.