### PR TITLE
Add support for `raw` client-level option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 
 - Fix cannot read response data included terminator `\r\n` when use meta protocol (matsubara0507)
 - Remove binary protocol support (grcooper)
+- Add support for `raw` client option (nherson)
 
 3.2.8
 ==========

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 group :development, :test do
   gem 'connection_pool'
+  gem 'debug'
   gem 'minitest', '~> 5'
   gem 'rack', '~> 2.0', '>= 2.2.0'
   gem 'rake', '~> 13.0'

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -35,6 +35,8 @@ module Dalli
     #                 to 0 or forever.
     # - :compress - if true Dalli will compress values larger than compression_min_size bytes before sending them
     #               to memcached.  Default: true.
+    # - :raw - if true Dalli will not attempt to serialize values, which can be overridden by explicitly passing
+    #          `:raw => false` as a request option when writing data. Default: false.
     # - :compression_min_size - the minimum size (in bytes) for which Dalli will compress values sent to Memcached.
     #                           Defaults to 4K.
     # - :serializer - defaults to Marshal

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -16,8 +16,7 @@ module Dalli
 
       attr_accessor :weight, :options
 
-      def_delegators :@value_marshaller, :serializer, :compressor, :compression_min_size,
-                     :compress_by_default?
+      def_delegators :@value_marshaller, :serializer, :compressor, :compression_min_size, :compress_by_default?
       def_delegators :@connection_manager, :name, :sock, :hostname, :port, :close, :connected?, :socket_timeout,
                      :socket_type, :up!, :down!, :write, :reconnect_down_server?, :raise_down_error
 

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -16,7 +16,7 @@ module Dalli
 
       attr_accessor :weight, :options
 
-      def_delegators :@value_marshaller, :serializer, :compressor, :compression_min_size, :compress_by_default?
+      def_delegators :@value_marshaller, :serializer, :raw_by_default?, :compressor, :compression_min_size, :compress_by_default?
       def_delegators :@connection_manager, :name, :sock, :hostname, :port, :close, :connected?, :socket_timeout,
                      :socket_type, :up!, :down!, :write, :reconnect_down_server?, :raise_down_error
 

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -16,7 +16,8 @@ module Dalli
 
       attr_accessor :weight, :options
 
-      def_delegators :@value_marshaller, :serializer, :raw_by_default?, :compressor, :compression_min_size, :compress_by_default?
+      def_delegators :@value_marshaller, :serializer, :raw_by_default?, :compressor, :compression_min_size,
+                     :compress_by_default?
       def_delegators :@connection_manager, :name, :sock, :hostname, :port, :close, :connected?, :socket_timeout,
                      :socket_type, :up!, :down!, :write, :reconnect_down_server?, :raise_down_error
 

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -16,7 +16,7 @@ module Dalli
 
       attr_accessor :weight, :options
 
-      def_delegators :@value_marshaller, :serializer, :raw_by_default?, :compressor, :compression_min_size,
+      def_delegators :@value_marshaller, :serializer, :compressor, :compression_min_size,
                      :compress_by_default?
       def_delegators :@connection_manager, :name, :sock, :hostname, :port, :close, :connected?, :socket_timeout,
                      :socket_type, :up!, :down!, :write, :reconnect_down_server?, :raise_down_error

--- a/lib/dalli/protocol/value_marshaller.rb
+++ b/lib/dalli/protocol/value_marshaller.rb
@@ -19,7 +19,7 @@ module Dalli
 
       OPTIONS = DEFAULTS.keys.freeze
 
-      def_delegators :@value_serializer, :serializer
+      def_delegators :@value_serializer, :serializer, :raw_by_default?
       def_delegators :@value_compressor, :compressor, :compression_min_size, :compress_by_default?
 
       def initialize(client_options)

--- a/lib/dalli/protocol/value_marshaller.rb
+++ b/lib/dalli/protocol/value_marshaller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require 'debug'
 
 module Dalli
   module Protocol
@@ -19,7 +20,7 @@ module Dalli
 
       OPTIONS = DEFAULTS.keys.freeze
 
-      def_delegators :@value_serializer, :serializer, :raw_by_default?
+      def_delegators :@value_serializer, :serializer
       def_delegators :@value_compressor, :compressor, :compression_min_size, :compress_by_default?
 
       def initialize(client_options)

--- a/lib/dalli/protocol/value_serializer.rb
+++ b/lib/dalli/protocol/value_serializer.rb
@@ -68,6 +68,7 @@ module Dalli
         # option and always refer to that when explicitly set (non-nil), otherwise
         # use the client default specified by `raw_by_default?`
         return !raw_by_default? unless req_options && !req_options[:raw].nil?
+
         !req_options[:raw]
       end
 

--- a/lib/dalli/protocol/value_serializer.rb
+++ b/lib/dalli/protocol/value_serializer.rb
@@ -63,10 +63,10 @@ module Dalli
         raise exc
       end
 
+      private
+
+      # Defaults to client-level option, unless a request-level override is provided
       def serialize_value?(req_options)
-        # When deciding when serialization is required, check the request-level
-        # option and always refer to that when explicitly set (non-nil), otherwise
-        # use the client default specified by `raw_by_default?`
         return !raw_by_default? unless req_options && !req_options[:raw].nil?
 
         !req_options[:raw]

--- a/test/protocol/test_value_serializer.rb
+++ b/test/protocol/test_value_serializer.rb
@@ -24,24 +24,6 @@ describe Dalli::Protocol::ValueSerializer do
         end
       end
     end
-
-    describe 'raw_by_default?' do
-      describe 'when the raw option is unspecified' do
-        let(:options) { {} }
-
-        it 'defaults to serialize' do
-          refute_predicate subject, :raw_by_default?
-        end
-      end
-
-      describe 'when the raw option is toggle on' do
-        let(:options) { { raw: true } }
-
-        it 'defaults to not serialize' do
-          assert_predicate subject, :raw_by_default?
-        end
-      end
-    end
   end
 
   describe 'store' do

--- a/test/protocol/test_value_serializer.rb
+++ b/test/protocol/test_value_serializer.rb
@@ -28,15 +28,17 @@ describe Dalli::Protocol::ValueSerializer do
     describe 'raw_by_default?' do
       describe 'when the raw option is unspecified' do
         let(:options) { {} }
+
         it 'defaults to serialize' do
-          assert_equal subject.raw_by_default?, false
+          refute_predicate subject, :raw_by_default?
         end
       end
 
       describe 'when the raw option is toggle on' do
         let(:options) { { raw: true } }
+
         it 'defaults to not serialize' do
-          assert_equal subject.raw_by_default?, true
+          assert_predicate subject, :raw_by_default?
         end
       end
     end

--- a/test/test_client_options.rb
+++ b/test/test_client_options.rb
@@ -4,9 +4,10 @@ require_relative 'helper'
 
 describe 'Dalli client options' do
   it 'not warn about valid options' do
-    dc = Dalli::Client.new('foo', compress: true)
+    dc = Dalli::Client.new('foo', compress: true, raw: true)
     # Rails.logger.expects :warn
     assert_operator dc.instance_variable_get(:@options), :[], :compress
+    assert_operator dc.instance_variable_get(:@options), :[], :raw
   end
 
   describe 'servers configuration' do


### PR DESCRIPTION
This change adds `raw: <boolean>` as a client level option for `Dalli::Client`.

Example usage: `c = Dalli::Client.new(["127.0.0.1:11211"], { raw: true })`

By default, `raw` is `false`. When `true`, the client will keep values "raw" as outlined in [the documentation](https://github.com/petergoldstein/dalli/wiki/Understanding-Serialization-and-Compression#raw-values), unless specified otherwise via an explicit `raw: false` option passed to a `set` op request.

Verifying behavior:

IRB Session
```
irb(main):013> c_raw = Dalli::Client.new(["127.0.0.1:1041"], {raw: true})
=> #<Dalli::Client:0x0000000124d7d168 @key_manager=#<Dalli::KeyManager:0x00000001250d1af8 @key_options={:digest_class=>Digest::MD5}, @namespace=nil>, @normalized_servers=["127.0.0.1:1041"], @options={:raw=>true}, @ring=nil>
irb(main):014> c_raw.set("should:be:raw", Object.new)
=> 2
irb(main):015> c_raw.get("should:be:raw")
=> "#<Object:0x0000000124e9e880>"
irb(main):016> c_serialized = Dalli::Client.new(["127.0.0.1:1041"])
=> #<Dalli::Client:0x0000000124d71fe8 @key_manager=#<Dalli::KeyManager:0x0000000125097a10 @key_options={:digest_class=>Digest::MD5}, @namespace=nil>, @normalized_servers=["127.0.0.1:1041"], @options={}, @ring=nil>
irb(main):017> c_serialized.set("should:not:be:raw", Object.new)
=> 3
irb(main):018> c_serialized.get("should:not:be:raw")
=> #<Object:0x00000001250bd6c0>
```
_(notice the first return value (`raw: true`) is a string with double quotes, the second (`raw: false`) is the original object deserialized)_

Telnet gets of the above data
```
$ telnet localhost 1041
Trying ::1...
Connected to localhost.
Escape character is '^]'.
get should:be:raw
VALUE should:be:raw 0 28
#<Object:0x0000000124e9e880>
END
get should:not:be:raw
VALUE should:not:be:raw 1 12
o:
  Object
END
```