### PR TITLE
Remove `require 'debug'`

### DIFF
--- a/lib/dalli/protocol/value_marshaller.rb
+++ b/lib/dalli/protocol/value_marshaller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'forwardable'
-require 'debug'
 
 module Dalli
   module Protocol


### PR DESCRIPTION
## Description

We can't build the gem because `debug` is specified as a development/test dependency but we are `require`ing it in a file.