### PR TITLE
Add retryable network errors

### DIFF
--- a/lib/dalli.rb
+++ b/lib/dalli.rb
@@ -12,6 +12,9 @@ module Dalli
   # socket/server communication error
   class NetworkError < DalliError; end
 
+  # socket/server communication error, but we should retry
+  class RetryableNetworkError < NetworkError; end
+
   # no server available/alive error
   class RingError < DalliError; end
 

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -436,7 +436,7 @@ module Dalli
 
       server = ring.server_for_key(key)
       server.request(op, key, *args)
-    rescue NetworkError => e
+    rescue RetryableNetworkError => e
       Dalli.logger.debug { e.inspect }
       Dalli.logger.debug { 'retrying request with new server' }
       retry

--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -14,10 +14,6 @@ module Dalli
       keys.map! { |a| @key_manager.validate_key(a.to_s) }
       results = @ring.servers.first.request(:read_multi_req, keys)
       @key_manager.key_values_without_namespace(results)
-    rescue NetworkError => e
-      Dalli.logger.debug { e.inspect }
-      Dalli.logger.debug { 'bailing on pipelined gets because of timeout' }
-      {}
     end
 
     ##

--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -36,7 +36,7 @@ module Dalli
       else
         optimized_for_single_server(keys)
       end
-    rescue NetworkError => e
+    rescue RetryableNetworkError => e
       Dalli.logger.debug { e.inspect }
       Dalli.logger.debug { 'retrying pipelined gets because of timeout' }
       retry
@@ -127,7 +127,7 @@ module Dalli
       servers
     rescue NetworkError
       # Abort and raise if we encountered a network error.  This triggers
-      # a retry at the top level.
+      # a retry at the top level on RetryableNetworkError
       abort_without_timeout(servers)
       raise
     end

--- a/lib/dalli/pipelined_setter.rb
+++ b/lib/dalli/pipelined_setter.rb
@@ -23,7 +23,7 @@ module Dalli
       @ring.servers.first.request(:write_multi_storage_req, :set, pairs, ttl, 0, req_options)
     rescue RetryableNetworkError => e
       Dalli.logger.debug { e.inspect }
-      Dalli.logger.debug { 'retrying pipelined gets because of timeout' }
+      Dalli.logger.debug { 'retrying pipelined set because of timeout' }
       retry
     end
   end

--- a/lib/dalli/pipelined_setter.rb
+++ b/lib/dalli/pipelined_setter.rb
@@ -21,9 +21,10 @@ module Dalli
       raise 'not yet implemented' unless @ring.servers.length == 1
 
       @ring.servers.first.request(:write_multi_storage_req, :set, pairs, ttl, 0, req_options)
-    rescue NetworkError => e
+    rescue RetryableNetworkError => e
       Dalli.logger.debug { e.inspect }
-      Dalli.logger.debug { 'bailing on pipelined set because of timeout' }
+      Dalli.logger.debug { 'retrying pipelined gets because of timeout' }
+      retry
     end
   end
 end

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -216,7 +216,7 @@ module Dalli
       def reconnect!(message)
         close
         sleep(options[:socket_failure_delay]) if options[:socket_failure_delay]
-        raise Dalli::NetworkError, message
+        raise Dalli::RetryableNetworkError, message
       end
 
       def reset_down_info

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,7 @@ require 'dalli'
 require 'logger'
 require 'securerandom'
 require 'toxiproxy'
+require 'debug'
 
 Dalli.logger = Logger.new($stdout)
 Dalli.logger.level = Logger::ERROR


### PR DESCRIPTION
Even when we set no retries for failures on the socket, we were still retrying. This is because `down!` and `reconnect!` both raised the same errors, which bubbled up to the `perform` methods and would call `retry` on that error.

I introduced a new `RetryableNetworkError` to only allow these retries when the server was not marked as down.

There were some cases where if the server continued to not be available we would continue to retry indefinitely.