### PR TITLE
🧹 remove redundant/unused arguments

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -454,7 +454,7 @@ module Dalli
     end
 
     def pipelined_setter
-      PipelinedSetter.new(ring, @key_manager)
+      PipelinedSetter.new(ring)
     end
   end
 end

--- a/lib/dalli/pipelined_setter.rb
+++ b/lib/dalli/pipelined_setter.rb
@@ -5,9 +5,8 @@ module Dalli
   # Contains logic for the pipelined sets implemented by the client.
   ##
   class PipelinedSetter
-    def initialize(ring, key_manager)
+    def initialize(ring)
       @ring = ring
-      @key_manager = key_manager
     end
 
     ##

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -42,7 +42,7 @@ module Dalli
         rescue Dalli::MarshalError => e
           log_marshal_err(args.first, e)
           raise
-        rescue Dalli::DalliError, Dalli::ServerError
+        rescue Dalli::DalliError
           raise
         rescue StandardError => e
           log_unexpected_err(e)


### PR DESCRIPTION
## Description

This PR removes the `key_manager` from PipelinedSetter since it is unused. Also, we don't need to explicitly rescue `Dalli::ServerError` since it inherits from `Dalli::DalliError`.