### PR TITLE
improvements on single get multi

### DIFF
--- a/lib/dalli/key_manager.rb
+++ b/lib/dalli/key_manager.rb
@@ -30,7 +30,7 @@ module Dalli
 
     def initialize(client_options)
       @key_options =
-        DEFAULTS.merge(client_options.select { |k, _| OPTIONS.include?(k) })
+        DEFAULTS.merge(client_options.slice(*OPTIONS))
       validate_digest_class_option(@key_options)
 
       @namespace = namespace_from_options

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -13,6 +13,7 @@ module Dalli
     ##
     class Meta < Base
       TERMINATOR = "\r\n"
+      SUPPORTS_CAPACITY = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
 
       def response_processor
         @response_processor ||= ResponseProcessor.new(@connection_manager, @value_marshaller)
@@ -51,9 +52,7 @@ module Dalli
       # rubocop:disable Metrics/AbcSize
       def read_multi_req(keys)
         # Pre-allocate the results hash with expected size
-        # NOTE: below is an optimization for Ruby 3.4, but we need a performant runtime check or deprecate
-        # results = {Hash.new(nil, capacity: keys.size)
-        results = {}
+        results = SUPPORTS_CAPACITY ? Hash.new(nil, capacity: keys.size) : {}
 
         keys.each do |key|
           @connection_manager.write("mg #{key} v f k q\r\n")

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -51,7 +51,9 @@ module Dalli
       # rubocop:disable Metrics/AbcSize
       def read_multi_req(keys)
         # Pre-allocate the results hash with expected size
-        results = Hash.new(keys.size)
+        # NOTE: below is an optimization for Ruby 3.4, but we need a performant runtime check or deprecate
+        # results = {Hash.new(nil, capacity: keys.size)
+        results = {}
 
         keys.each do |key|
           @connection_manager.write("mg #{key} v f k q\r\n")

--- a/lib/dalli/protocol/meta/response_processor.rb
+++ b/lib/dalli/protocol/meta/response_processor.rb
@@ -244,7 +244,9 @@ module Dalli
         end
 
         def read_data(data_size)
-          @io_source.read(data_size + TERMINATOR.bytesize)&.chomp!(TERMINATOR)
+          resp_data = @io_source.read(data_size)
+          @io_source.read(TERMINATOR.bytesize)
+          resp_data
         end
       end
     end

--- a/lib/dalli/protocol/value_compressor.rb
+++ b/lib/dalli/protocol/value_compressor.rb
@@ -35,7 +35,7 @@ module Dalli
         end
 
         @compression_options =
-          DEFAULTS.merge(client_options.select { |k, _| OPTIONS.include?(k) })
+          DEFAULTS.merge(client_options.slice(*OPTIONS))
       end
 
       def store(value, req_options, bitflags)

--- a/lib/dalli/protocol/value_marshaller.rb
+++ b/lib/dalli/protocol/value_marshaller.rb
@@ -27,7 +27,7 @@ module Dalli
         @value_compressor = ValueCompressor.new(client_options)
 
         @marshal_options =
-          DEFAULTS.merge(client_options.select { |k, _| OPTIONS.include?(k) })
+          DEFAULTS.merge(client_options.slice(*OPTIONS))
       end
 
       def store(key, value, options = nil)

--- a/lib/dalli/protocol/value_serializer.rb
+++ b/lib/dalli/protocol/value_serializer.rb
@@ -24,7 +24,7 @@ module Dalli
 
       def initialize(protocol_options)
         @serialization_options =
-          DEFAULTS.merge(protocol_options.select { |k, _| OPTIONS.include?(k) })
+          DEFAULTS.merge(protocol_options.slice(*OPTIONS))
       end
 
       def store(value, req_options, bitflags)


### PR DESCRIPTION
This PR improves the optimized single server get multi, the primary fixes were reducing the number of chomps!, reducing allocations with byteslice, preallocate expected hash size...


benchmark before:

```
Comparison:
       Ecc get_multi:      453.6 i/s
 EccClient get_multi:      448.8 i/s - same-ish: difference falls within error
      Sock get multi:      431.3 i/s - same-ish: difference falls within error
  EccStore get_multi:      424.1 i/s - same-ish: difference falls within error
DalliClient get_multi:      366.6 i/s - 1.24x  slower
DalliStore get_multi:      360.3 i/s - 1.26x  slower
     Dalli get multi:      344.7 i/s - 1.32x  slower
 FileStore get multi:      341.7 i/s - 1.33x  slower
MemCacheStore get multi:      327.6 i/s - 1.38x  slower
```

benchmark after

```
Comparison:
       Ecc get_multi:      424.2 i/s
      Sock get multi:      408.5 i/s - same-ish: difference falls within error
DalliStore get_multi:      392.2 i/s - same-ish: difference falls within error
 EccClient get_multi:      377.6 i/s - same-ish: difference falls within error
DalliClient get_multi:      373.5 i/s - same-ish: difference falls within error
  EccStore get_multi:      356.1 i/s - same-ish: difference falls within error
     Dalli get multi:      349.4 i/s - 1.21x  slower
```