### PR TITLE
add support for simple_set which allows for around 2x faster sets

### DIFF
--- a/lib/dalli/protocol/meta/request_formatter.rb
+++ b/lib/dalli/protocol/meta/request_formatter.rb
@@ -28,10 +28,10 @@ module Dalli
 
         def self.meta_set(key:, value:, bitflags: nil, cas: nil, ttl: nil, mode: :set, base64: false, quiet: false)
           cmd = "ms #{key} #{value.bytesize}"
-          cmd << ' c' unless %i[append prepend].include?(mode)
+          cmd << ' c' if !quiet && !%i[append prepend].include?(mode)
           cmd << ' b' if base64
           cmd << " F#{bitflags}" if bitflags
-          cmd << cas_string(cas)
+          cmd << cas_string(cas) if cas
           cmd << " T#{ttl}" if ttl
           cmd << " M#{mode_to_token(mode)}"
           cmd << ' q' if quiet

--- a/test/protocol/meta/test_request_formatter.rb
+++ b/test/protocol/meta/test_request_formatter.rb
@@ -89,7 +89,7 @@ describe Dalli::Protocol::Meta::RequestFormatter do
     end
 
     it 'sets the quiet mode if configured' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS q\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} F#{bitflags} MS q\r\n#{val}\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     quiet: true)
     end


### PR DESCRIPTION
ok, this is a bit silly and we clearly need to revisit how we build request strings as the single server multi set and this change both make most of their gains just by avoiding building the command as a new string and then sending it to the socket, but instead build the command by sending to the socket, which reduces copying of the string and new object allocations as well as string manipulation... this one is valuable enough we probably want to add it for usage while we sort out a better pattern.

---

prior profile (__Note: the `RequestFormatter` and string append calls__):
<img width="1511" alt="Screenshot 2025-01-30 at 10 21 34 PM" src="https://github.com/user-attachments/assets/6a1fc820-1707-4bec-b9ae-4b516c01fab0" />


after these changes:
<img width="1510" alt="Screenshot 2025-01-30 at 10 22 22 PM" src="https://github.com/user-attachments/assets/74594b68-5b7d-4b92-85ba-353a31325721" />

benchmarks...

```
Comparison:
          socket set:     8616.0 i/s
    Dalli set simple:     7426.9 i/s - 1.16x  slower
             Ecc set:     6296.3 i/s - 1.37x  slower
        EccStore set:     5814.0 i/s - 1.48x  slower
       EccClient set:     5809.0 i/s - 1.48x  slower
      Dalli set norm:     3015.3 i/s - 2.86x  slower
   MemCacheStore set:     2762.0 i/s - 3.12x  slower
      DalliStore set:     2660.7 i/s - 3.24x  slower
     DalliClient set:     2489.0 i/s - 3.46x  slower
       FileStore set:     1911.7 i/s - 4.51x  slower
```