### PR TITLE
improve set by 2.5 for simple use cases

### DIFF
--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -148,6 +148,8 @@ module Dalli
                                         bitflags: bitflags, cas: cas,
                                         ttl: ttl, mode: mode, quiet: quiet?, base64: base64)
         write(req)
+        write(value)
+        write(TERMINATOR)
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -168,6 +170,8 @@ module Dalli
         req = RequestFormatter.meta_set(key: encoded_key, value: value, base64: base64,
                                         cas: cas, ttl: ttl, mode: mode, quiet: quiet?)
         write(req)
+        write(value)
+        write(TERMINATOR)
       end
       # rubocop:enable Metrics/ParameterLists
 

--- a/lib/dalli/protocol/meta/request_formatter.rb
+++ b/lib/dalli/protocol/meta/request_formatter.rb
@@ -28,16 +28,14 @@ module Dalli
 
         def self.meta_set(key:, value:, bitflags: nil, cas: nil, ttl: nil, mode: :set, base64: false, quiet: false)
           cmd = "ms #{key} #{value.bytesize}"
-          cmd << ' c' unless %i[append prepend].include?(mode)
+          cmd << ' c' if !quiet && !%i[append prepend].include?(mode)
           cmd << ' b' if base64
           cmd << " F#{bitflags}" if bitflags
-          cmd << cas_string(cas)
+          cmd << cas_string(cas) if cas && cas != 0
           cmd << " T#{ttl}" if ttl
           cmd << " M#{mode_to_token(mode)}"
           cmd << ' q' if quiet
           cmd << TERMINATOR
-          cmd << value
-          cmd + TERMINATOR
         end
 
         def self.meta_delete(key:, cas: nil, ttl: nil, base64: false, quiet: false)

--- a/test/protocol/meta/test_request_formatter.rb
+++ b/test/protocol/meta/test_request_formatter.rb
@@ -41,61 +41,61 @@ describe Dalli::Protocol::Meta::RequestFormatter do
     let(:ttl) { rand(500..999) }
 
     it 'returns the default (treat as a set, no CAS check) when just passed key, datalen, and bitflags' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags)
     end
 
     it 'supports the add mode' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} ME\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} ME\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     mode: :add)
     end
 
     it 'supports the replace mode' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MR\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MR\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     mode: :replace)
     end
 
     it 'passes a TTL if one is provided' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} T#{ttl} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} T#{ttl} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, ttl: ttl, bitflags: bitflags)
     end
 
     it 'omits the CAS flag on append' do
-      assert_equal "ms #{key} #{val.bytesize} MA\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} MA\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, mode: :append)
     end
 
     it 'omits the CAS flag on prepend' do
-      assert_equal "ms #{key} #{val.bytesize} MP\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} MP\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, mode: :prepend)
     end
 
     it 'passes a CAS if one is provided' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} C#{cas} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} C#{cas} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags, cas: cas)
     end
 
     it 'excludes CAS if set to 0' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags, cas: 0)
     end
 
     it 'excludes non-numeric CAS values' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     cas: "\nset importantkey 1 1000 8\ninjected")
     end
 
     it 'sets the quiet mode if configured' do
-      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS q\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} F#{bitflags} MS q\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     quiet: true)
     end
 
     it 'sets the base64 mode if configured' do
-      assert_equal "ms #{key} #{val.bytesize} c b F#{bitflags} MS\r\n#{val}\r\n",
+      assert_equal "ms #{key} #{val.bytesize} c b F#{bitflags} MS\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     base64: true)
     end


### PR DESCRIPTION
This speeds up set calls by over 2X generally because we will avoid copying and extra allocations for large values.

---

set before:

```
Warming up --------------------------------------
          client set   304.000 i/100ms
        raw sock set   827.000 i/100ms
Calculating -------------------------------------
          client set      2.998k (± 8.9%) i/s  (333.52 μs/i) -     29.792k in  10.009832s
        raw sock set      8.254k (± 2.8%) i/s  (121.15 μs/i) -     82.700k in  10.027442s

Comparison:
        raw sock set:     8254.3 i/s
          client set:     2998.4 i/s - 2.75x  slower
```

set now:

```
Warming up --------------------------------------
          client set   724.000 i/100ms
        raw sock set   828.000 i/100ms
Calculating -------------------------------------
          client set      7.434k (± 2.4%) i/s  (134.51 μs/i) -     74.572k in  10.037368s
        raw sock set      8.209k (± 4.5%) i/s  (121.82 μs/i) -     81.972k in  10.011659s

Comparison:
        raw sock set:     8208.7 i/s
          client set:     7434.2 i/s - 1.10x  slower
```