### PR TITLE
optimization around get for raw usage

### DIFF
--- a/lib/dalli/protocol/meta/response_processor.rb
+++ b/lib/dalli/protocol/meta/response_processor.rb
@@ -28,12 +28,16 @@ module Dalli
           @value_marshaller = value_marshaller
         end
 
-        def meta_get_with_value(cache_nils: false)
+        def meta_get_with_value(cache_nils: false, skip_flags: false)
           tokens = error_on_unexpected!([VA, EN, HD])
           return cache_nils ? ::Dalli::NOT_FOUND : nil if tokens.first == EN
           return true unless tokens.first == VA
 
-          @value_marshaller.retrieve(read_data(tokens[1].to_i), bitflags_from_tokens(tokens))
+          if skip_flags
+            @value_marshaller.retrieve(read_data(tokens[1].to_i), 0)
+          else
+            @value_marshaller.retrieve(read_data(tokens[1].to_i), bitflags_from_tokens(tokens))
+          end
         end
 
         def meta_get_with_value_and_cas

--- a/lib/dalli/protocol/value_marshaller.rb
+++ b/lib/dalli/protocol/value_marshaller.rb
@@ -22,9 +22,12 @@ module Dalli
       def_delegators :@value_serializer, :serializer
       def_delegators :@value_compressor, :compressor, :compression_min_size, :compress_by_default?
 
+      attr_reader :raw_by_default
+
       def initialize(client_options)
         @value_serializer = ValueSerializer.new(client_options)
         @value_compressor = ValueCompressor.new(client_options)
+        @raw_by_default = client_options[:raw] || false
 
         @marshal_options =
           DEFAULTS.merge(client_options.slice(*OPTIONS))


### PR DESCRIPTION
OK, starting to hit a wall with most of the profile and benchmark data, but we will talk more with some YJIT folks next week. 

This is a small win, but does show up in the profiles and benchmarks, and should be more significant with remote vs local memcached servers as it reduces the total bytes on the socket write and read. 

* multi_get goes from 1.27x slower to 1.20x slower than raw socket
* get goes from 1.17x  slower to 1.14x slower than raw socket

---

multi_get before:

```
❯❯❯$ BENCH_TARGET=get_multi RUBY_YJIT_ENABLE=1 bundle exec bin/benchmark                                      <bundler> [faster_get]
yjit: true
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        get 100 keys    33.000 i/100ms
get 100 keys raw sock
                        39.000 i/100ms
Calculating -------------------------------------
        get 100 keys    333.944 (± 4.8%) i/s    (2.99 ms/i) -      3.333k in  10.003634s
get 100 keys raw sock
                        422.941 (± 7.3%) i/s    (2.36 ms/i) -      4.212k in  10.009880s

Comparison:
get 100 keys raw sock:      422.9 i/s
        get 100 keys:      333.9 i/s - 1.27x  slower
```

multi_get after:

```
❯❯❯$ BENCH_TARGET=get_multi RUBY_YJIT_ENABLE=1 bundle exec bin/benchmark                                    <bundler> [faster_get ●]
yjit: true
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        get 100 keys    33.000 i/100ms
get 100 keys raw sock
                        42.000 i/100ms
Calculating -------------------------------------
        get 100 keys    344.285 (± 5.2%) i/s    (2.90 ms/i) -      3.465k in  10.092004s
get 100 keys raw sock
                        412.262 (± 5.3%) i/s    (2.43 ms/i) -      4.116k in  10.012749s

Comparison:
get 100 keys raw sock:      412.3 i/s
        get 100 keys:      344.3 i/s - 1.20x  slower
```

and get before:

```
❯❯❯$ BENCH_TARGET=get RUBY_YJIT_ENABLE=1 bundle exec bin/benchmark                                            <bundler> [faster_get]
yjit: true
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
           get dalli   352.000 i/100ms
            get sock   399.000 i/100ms
get sock non-blocking
                       342.000 i/100ms
Calculating -------------------------------------
           get dalli      3.436k (± 5.1%) i/s  (291.01 μs/i) -     34.496k in  10.066406s
            get sock      4.016k (± 3.0%) i/s  (248.99 μs/i) -     40.299k in  10.042930s
get sock non-blocking
                          3.448k (± 5.9%) i/s  (290.00 μs/i) -     34.542k in  10.046747s

Comparison:
            get sock:     4016.2 i/s
get sock non-blocking:     3448.3 i/s - 1.16x  slower
           get dalli:     3436.3 i/s - 1.17x  slower
```

and get after:

```
❯❯❯$ BENCH_TARGET=get RUBY_YJIT_ENABLE=1 bundle exec bin/benchmark                                          <bundler> [faster_get ●]
yjit: true
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
           get dalli   353.000 i/100ms
            get sock   397.000 i/100ms
get sock non-blocking
                       356.000 i/100ms
Calculating -------------------------------------
           get dalli      3.540k (± 3.5%) i/s  (282.45 μs/i) -     35.653k in  10.082393s
            get sock      4.028k (± 3.5%) i/s  (248.25 μs/i) -     40.494k in  10.064542s
get sock non-blocking
                          3.548k (± 4.3%) i/s  (281.86 μs/i) -     35.600k in  10.050622s

Comparison:
            get sock:     4028.3 i/s
get sock non-blocking:     3547.8 i/s - 1.14x  slower
           get dalli:     3540.5 i/s - 1.14x  slower
```