### PR TITLE
add ruby 3.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         ruby-version:
           - head
+          - '3.4'
           - '3.3'
           - '3.2'
         memcached-version: ['1.6.23']


### PR DESCRIPTION
we test against ruby head, but we should also test against the stable 3.4 release