### PR TITLE
Rescue IOError for connection manager write/flush to account for `IOError: closed stream` errors

### DIFF
--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -174,7 +174,7 @@ module Dalli
 
       def write(bytes)
         @sock.write(bytes)
-      rescue SystemCallError, *TIMEOUT_ERRORS => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, IOError => e
         error_on_request!(e)
       end
 
@@ -186,7 +186,7 @@ module Dalli
 
       def flush
         @sock.flush
-      rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
+      rescue SystemCallError, *TIMEOUT_ERRORS, IOError => e
         error_on_request!(e)
       end
 

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -49,6 +49,19 @@ describe 'Network' do
         end
       end
     end
+
+    it 'handles closed socket' do
+      toxi_memcached_persistent(MemcachedManager::TOXIPROXY_UPSTREAM_PORT, '', { socket_timeout: 1 }) do |dc|
+        dc.set('test_key', 'test_value')
+
+        # Force close the socket
+        server = dc.instance_variable_get(:@ring).servers.first
+        socket = server.instance_variable_get(:@connection_manager).sock
+        socket&.close
+
+        assert_equal 'test_value', dc.get('test_key')
+      end
+    end
   end
 
   it 'opens a standard TCP connection when ssl_context is not configured' do


### PR DESCRIPTION
We've been noticing `IOError: closed stream` during CI runs with the following stack trace

```
IOError: closed stream 
url=https://github.com/Shopify/dalli/blob/ee18f497d0f20e7e66c0b41266713ce377ece3c6/lib/dalli/protocol/connection_manager.rb#L176;content=(dalli-ee18f497d0f2) lib/dalli/protocol/connection_manager.rb:176 in `IO#write` 
url=https://github.com/Shopify/dalli/blob/ee18f497d0f20e7e66c0b41266713ce377ece3c6/lib/dalli/protocol/connection_manager.rb#L176;content=(dalli-ee18f497d0f2) lib/dalli/protocol/connection_manager.rb:176 in `Dalli::Protocol::ConnectionManager#write`
url=<partially_redacted>/usr/local/ruby/lib/ruby/3.4.0/forwardable.rb#L240;content=/usr/local/ruby/lib/ruby/3.4.0/forwardable.rb:240 in `Dalli::Protocol::Base#write` 
url=https://github.com/Shopify/dalli/blob/ee18f497d0f20e7e66c0b41266713ce377ece3c6/lib/dalli/protocol/meta.rb#L224;content=(dalli-ee18f497d0f2) lib/dalli/protocol/meta.rb:224 in `Dalli::Protocol::Meta#decr_incr` 
url=https://github.com/Shopify/dalli/blob/ee18f497d0f20e7e66c0b41266713ce377ece3c6/lib/dalli/protocol/meta.rb#L218;content=(dalli-ee18f497d0f2) lib/dalli/protocol/meta.rb:218 in `Dalli::Protocol::Meta#incr` 
url=https://github.com/Shopify/dalli/blob/ee18f497d0f20e7e66c0b41266713ce377ece3c6/lib/dalli/protocol/base.rb#L37;content=(dalli-ee18f497d0f2) lib/dalli/protocol/base.rb:37 in `Dalli::Protocol::Base#request` 
```

I was able to reproduce the the exception in `ConnectionManager#write` using the following (force closing of the socket)

```ruby
require 'dalli'

# Create a Dalli client
dc = Dalli::Client.new('localhost:11211')

# Set a value
dc.set('test_key', 'test_value')

# Get the underlying socket connection
server = dc.instance_variable_get(:@ring).servers.first
socket = server.instance_variable_get(:@connection_manager).sock

# Force close the socket
socket&.close
dc.get('test_key')
```

The reproduction is captured in the test added (test fails with `IOError: closed stream` if we don't rescue `IOError`)

Some thoughts:

- Why not keep `EOFError`? 
    * `EOFError` is a subclass of `IOError`, linter complains if both exist in the same rescue block
- I wasn't able to reproduce it for other methods, should we still rescue `IOError` instead of `EOFError` everywhere? Do we risk catching too broad of an error in that case?