### PR TITLE
Buffered I/O

### DIFF
--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -53,6 +53,7 @@ module Dalli
         Dalli.logger.debug { "Dalli::Server#connect #{name}" }
 
         @sock = memcached_socket
+        @sock.sync = false
         @pid = PIDCache.pid
         @request_in_progress = false
       rescue SystemCallError, *TIMEOUT_ERRORS, EOFError, SocketError => e

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -256,6 +256,7 @@ module Dalli
 
       def write_noop
         write(RequestFormatter.meta_noop)
+        @connection_manager.flush
       end
 
       def authenticate_connection

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -101,6 +101,7 @@ module Dalli
         else
           write(RequestFormatter.meta_get(key: encoded_key, base64: base64, meta_flags: meta_options))
         end
+        @connection_manager.flush
         if !meta_options && !base64 && !quiet? && @value_marshaller.raw_by_default
           response_processor.meta_get_with_value(cache_nils: cache_nils?(options), skip_flags: true)
         elsif meta_options
@@ -124,6 +125,7 @@ module Dalli
         req = RequestFormatter.meta_get(key: encoded_key, ttl: ttl, base64: base64,
                                         meta_flags: meta_flag_options(options))
         write(req)
+        @connection_manager.flush
         if meta_flag_options(options)
           response_processor.meta_get_with_value_and_meta_flags(cache_nils: cache_nils?(options))
         else
@@ -136,6 +138,7 @@ module Dalli
         encoded_key, base64 = KeyRegularizer.encode(key)
         req = RequestFormatter.meta_get(key: encoded_key, ttl: ttl, value: false, base64: base64)
         write(req)
+        @connection_manager.flush
         response_processor.meta_get_without_value
       end
 
@@ -145,6 +148,7 @@ module Dalli
         encoded_key, base64 = KeyRegularizer.encode(key)
         req = RequestFormatter.meta_get(key: encoded_key, value: true, return_cas: true, base64: base64)
         write(req)
+        @connection_manager.flush
         response_processor.meta_get_with_value_and_cas
       end
 
@@ -175,6 +179,7 @@ module Dalli
         write(req)
         write(value)
         write(TERMINATOR)
+        @connection_manager.flush
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -197,6 +202,7 @@ module Dalli
         write(req)
         write(value)
         write(TERMINATOR)
+        @connection_manager.flush
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -206,6 +212,7 @@ module Dalli
         req = RequestFormatter.meta_delete(key: encoded_key, cas: cas,
                                            base64: base64, quiet: quiet?)
         write(req)
+        @connection_manager.flush
         response_processor.meta_delete unless quiet?
       end
 
@@ -223,12 +230,14 @@ module Dalli
         encoded_key, base64 = KeyRegularizer.encode(key)
         write(RequestFormatter.meta_arithmetic(key: encoded_key, delta: delta, initial: initial, incr: incr, ttl: ttl,
                                                quiet: quiet?, base64: base64))
+        @connection_manager.flush
         response_processor.decr_incr unless quiet?
       end
 
       # Other Commands
       def flush(delay = 0)
         write(RequestFormatter.flush(delay: delay))
+        @connection_manager.flush
         response_processor.flush unless quiet?
       end
 
@@ -236,21 +245,25 @@ module Dalli
       # We need to read all the responses at once.
       def noop
         write_noop
+        @connection_manager.flush
         response_processor.consume_all_responses_until_mn
       end
 
       def stats(info = nil)
         write(RequestFormatter.stats(info))
+        @connection_manager.flush
         response_processor.stats
       end
 
       def reset_stats
         write(RequestFormatter.stats('reset'))
+        @connection_manager.flush
         response_processor.reset
       end
 
       def version
         write(RequestFormatter.version)
+        @connection_manager.flush
         response_processor.version
       end
 


### PR DESCRIPTION
## Description

By default, it does not seem that Ruby's TCP or UNIX sockets used buffered I/O. This means that every `@sock.write` results in a `write(2)` syscall. Based on analyzing various flamegraphs, this is prohibitively expensive for `read_multi` requests where we spend >50% of the time writing keys to Memcached where, intuitively, we should be spending reading the payload back. This is because we [perform a write syscall for every key](https://github.com/Shopify/dalli/blob/764b3a65b1c73d4b850e49ff9f3190f8e76de8aa/lib/dalli/protocol/meta.rb#L64-L66).

```
irb(main):001> require "socket"
=> true
irb(main):002> s = TCPSocket.new("google.com", 80)
=> #<TCPSocket:fd 8, AF_INET, 192.168.2.23, 49454>
irb(main):003> s.sync
=> true
```

Here's the top frames on a `get_multi` with 100 key-value pairs where the value is 50KiB:

## Non-buffered I/O
```
  GC: 2437 (12.66%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      9645  (50.1%)        9645  (50.1%)     IO#read
      7122  (37.0%)        7122  (37.0%)     IO#write
      2361  (12.3%)        2361  (12.3%)     (sweeping)
        72   (0.4%)          72   (0.4%)     (marking)
        41   (0.2%)          41   (0.2%)     IO#readline
     16818  (87.3%)           6   (0.0%)     Dalli::Protocol::Meta#read_multi_req
```

## Buffered I/O
```
  GC: 2381 (16.83%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     10590  (74.9%)       10590  (74.9%)     IO#read
      2286  (16.2%)        2286  (16.2%)     (sweeping)
       973   (6.9%)         973   (6.9%)     IO#flush
       104   (0.7%)         104   (0.7%)     IO#readline
        84   (0.6%)          84   (0.6%)     (marking)
        56   (0.4%)          56   (0.4%)     IO#write
     11758  (83.1%)          15   (0.1%)     Dalli::Protocol::Meta#read_multi_req
```

Operation | Payload Size | Non-buffered I/O (i/s) | Buffered I/O (i/s) | Improvement (%)
-- | -- | -- | -- | --
set | 8 bytes | 25.905k | 30.464k | +17.6%
set | 1 KiB | 24.005k | 30.033k | +25.1%
set | 32 KiB | 21.437k | 20.497k | -4.4%
set | 128 KiB | 13.965k | 15.470k | +10.8%
set | 1 MiB | 4.056k | 4.065k | +0.2%
get | 8 bytes | 32.919k | 34.596k | +5.1%
get | 1 KiB | 32.480k | 32.782k | +0.9%
get | 32 KiB | 27.321k | 23.684k | -13.5%
get | 128 KiB | 17.032k | 14.145k | -17.0%
get | 1 MiB | 3.887k | 3.483k | -10.4%
set_multi | 8 bytes | 981.252 | 3.901k | +296.5%
set_multi | 1 KiB | 968.807 | 3.301k | +240.4%
set_multi | 32 KiB | 762.528 | 1.125k | +47.6%
set_multi | 128 KiB | 401.726 | 479.818 | +19.4%
set_multi | 1 MiB | 71.000 | 70.954 | -0.1%
get_multi | 8 bytes | 1.711k | 3.597k | +109.5%
get_multi | 1 KiB | 1.708k | 3.300k | +93.1%
get_multi | 32 KiB | 1.013k | 1.260k | +24.4%
get_multi | 128 KiB | 261.964 | 401.511 | +53.2%
get_multi | 1 MiB | 90.506 | 80.809 | -10.7%
