### PR TITLE
Re-name OTel span names to match Rails Cache API

### DIFF
--- a/lib/dalli/opentelemetry_middleware.rb
+++ b/lib/dalli/opentelemetry_middleware.rb
@@ -12,7 +12,7 @@ module Dalli
     }.freeze
 
     def storage_req(operation, tags = {})
-      TRACER.in_span(operation.to_s, attributes: tags.merge!(DEFAULT_TRACE_ATTRIBUTES), kind: :client) do |span|
+      TRACER.in_span(operation, attributes: tags.merge!(DEFAULT_TRACE_ATTRIBUTES), kind: :client) do |span|
         attributes = {}
         result = yield attributes
         span.add_attributes(attributes)
@@ -21,7 +21,7 @@ module Dalli
     end
 
     def retrieve_req(operation, tags = {})
-      TRACER.in_span(operation.to_s, attributes: tags.merge!(DEFAULT_TRACE_ATTRIBUTES), kind: :client) do |span|
+      TRACER.in_span(operation, attributes: tags.merge!(DEFAULT_TRACE_ATTRIBUTES), kind: :client) do |span|
         attributes = {}
         result = yield attributes
         span.add_attributes(attributes)
@@ -30,7 +30,7 @@ module Dalli
     end
 
     def storage_req_pipeline(operation, tags = {})
-      TRACER.in_span(operation.to_s, attributes: tags.merge!(DEFAULT_TRACE_ATTRIBUTES), kind: :client) do |span|
+      TRACER.in_span(operation, attributes: tags.merge!(DEFAULT_TRACE_ATTRIBUTES), kind: :client) do |span|
         attributes = {}
         result = yield attributes
         span.add_attributes(attributes)
@@ -39,7 +39,7 @@ module Dalli
     end
 
     def retrieve_req_pipeline(operation, tags = {})
-      TRACER.in_span(operation.to_s, attributes: tags.merge!(DEFAULT_TRACE_ATTRIBUTES), kind: :client) do |span|
+      TRACER.in_span(operation, attributes: tags.merge!(DEFAULT_TRACE_ATTRIBUTES), kind: :client) do |span|
         attributes = {}
         result = yield attributes
         span.add_attributes(attributes)

--- a/test/test_middlewares.rb
+++ b/test/test_middlewares.rb
@@ -41,8 +41,8 @@ describe 'Middlewares' do
       middleware_stack = dc.send(:ring).servers.first.instance_variable_get(:@middlewares_stack)
       calls = middleware_stack.recorded_calls
 
-      assert(calls.any? { |t, op, _| t == :storage_req && op == 'set' })
-      assert(calls.any? { |t, op, _| t == :retrieve_req && op == 'get' })
+      assert(calls.any? { |t, op, _| t == :storage_req && op == 'write' })
+      assert(calls.any? { |t, op, _| t == :retrieve_req && op == 'read' })
     end
   end
 
@@ -54,8 +54,8 @@ describe 'Middlewares' do
       middleware_stack = dc.send(:ring).servers.first.instance_variable_get(:@middlewares_stack)
       calls = middleware_stack.recorded_calls
 
-      assert(calls.any? { |t, op, _| t == :storage_req_pipeline && op == 'setq' })
-      assert(calls.any? { |t, op, _| t == :retrieve_req_pipeline && op == 'getq' })
+      assert(calls.any? { |t, op, _| t == :storage_req_pipeline && op == 'write_multi' })
+      assert(calls.any? { |t, op, _| t == :retrieve_req_pipeline && op == 'read_multi' })
     end
   end
 end

--- a/test/test_opentelemetry_middleware.rb
+++ b/test/test_opentelemetry_middleware.rb
@@ -14,8 +14,8 @@ describe 'OpenTelemetry middleware' do
       finished = OTEL_EXPORTER.respond_to?(:finished_spans) ? OTEL_EXPORTER.finished_spans : []
       names = finished.map(&:name)
 
-      assert_includes names, 'set', "expected a 'set' span, got: #{names.inspect}"
-      assert_includes names, 'get', "expected a 'get' span, got: #{names.inspect}"
+      assert_includes names, 'write', "expected a 'write' span, got: #{names.inspect}"
+      assert_includes names, 'read', "expected a 'read' span, got: #{names.inspect}"
     end
   end
 end


### PR DESCRIPTION
## What

This PR renames the operation span names to match the [Rails cache API](https://api.rubyonrails.org/v7.1/classes/ActiveSupport/Cache/Store.html).