### PR TITLE
Eliminate double array allocation in Client#perform

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -440,10 +440,10 @@ module Dalli
     # a particular memcached instance becomes unreachable, or the
     # operational times out.
     ##
-    def perform(*all_args)
+    # rubocop:disable Naming/MethodParameterName
+    def perform(op, key, *args)
+      # rubocop:enable Naming/MethodParameterName
       return yield if block_given?
-
-      op, key, *args = all_args
 
       key = key.to_s
       key = @key_manager.validate_key(key)

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -440,7 +440,7 @@ module Dalli
     # a particular memcached instance becomes unreachable, or the
     # operational times out.
     ##
-    # rubocop:disable Naming/MethodParameterName
+    # rubocop:disable Naming/MethodParameterName, Style/ArgumentsForwarding
     def perform(op, key, *args)
       # rubocop:enable Naming/MethodParameterName
       return yield if block_given?
@@ -450,6 +450,7 @@ module Dalli
 
       server = ring.server_for_key(key)
       server.request(op, key, *args)
+      # rubocop:enable Style/ArgumentsForwarding
     rescue RetryableNetworkError => e
       Dalli.logger.debug { e.inspect }
       Dalli.logger.debug { 'retrying request with new server' }

--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -164,7 +164,7 @@ module Dalli
       # individual servers, but I'm not sure.  For now, we keep the
       # mapping between the alerted object (the socket) and the
       # corrresponding server here.
-      server_map = servers.each_with_object({}) { |s, h| h[s.sock] = s }
+      server_map = servers.to_h { |s| [s.sock, s] }
 
       readable, = IO.select(server_map.keys, nil, nil, timeout)
       return [] if readable.nil?

--- a/lib/dalli/socket.rb
+++ b/lib/dalli/socket.rb
@@ -94,7 +94,7 @@ module Dalli
         # To check this we are using the fact that resolv-replace
         # aliases TCPSocket#initialize method to #original_resolv_initialize.
         # https://github.com/ruby/resolv-replace/blob/v0.1.1/lib/resolv-replace.rb#L21
-        if ::TCPSocket.private_instance_methods.include?(:original_resolv_initialize)
+        if ::TCPSocket.private_method_defined?(:original_resolv_initialize)
           Timeout.timeout(options[:socket_timeout]) do
             sock = new(host, port)
             yield(sock)


### PR DESCRIPTION
Pulling this fix into our fork: https://github.com/petergoldstein/dalli/pull/1093