### PR TITLE
Harden ConnectionManager#close against non-StandardError during @sock.close

### DIFF
--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -117,10 +117,16 @@ module Dalli
           @sock.close
         rescue StandardError
           nil
+        ensure
+          # A non-StandardError (e.g. a second Async::Stop fired into the
+          # fiber while it's already inside ensure-cleanup) can escape
+          # @sock.close; run the state cleanup unconditionally so the client
+          # isn't returned to the pool with a half-closed socket and
+          # @request_in_progress == true.
+          @sock = nil
+          @pid = nil
+          abort_request!
         end
-        @sock = nil
-        @pid = nil
-        abort_request!
       end
 
       def connected?

--- a/test/integration/test_fiber_concurrency.rb
+++ b/test/integration/test_fiber_concurrency.rb
@@ -57,4 +57,39 @@ describe 'fiber concurrency' do
                       "expected close to run during non-StandardError abort, got close_count=#{close_count}"
     end
   end
+
+  # A second Async::Stop landing on the fiber while it is already inside the
+  # `ensure` cleanup from the first one would interrupt `@sock.close`.
+  # `ConnectionManager#close` rescues only StandardError around the socket
+  # close, so a non-StandardError escaping `@sock.close` leaves `@sock`
+  # non-nil and skips `abort_request!` — the client is returned to the pool
+  # with `@request_in_progress == true` and a half-closed socket.
+  it 'cleans up when @sock.close itself is interrupted by a second non-StandardError' do
+    memcached_persistent do |dc|
+      dc.flush
+      dc.set('a', 'val_a') # warms up the connection so @sock exists
+
+      conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+      sock = conn_mgr.instance_variable_get(:@sock)
+
+      refute_nil sock, 'precondition: socket should be connected after set'
+
+      # Second cancellation: fires when close() reaches @sock.close.
+      sock.define_singleton_method(:close) do
+        raise FiberCancellation, 'simulated second fiber cancellation during @sock.close'
+      end
+
+      # First cancellation: fires when the request parks on a read.
+      conn_mgr.define_singleton_method(:read_line) do
+        raise FiberCancellation, 'simulated first fiber cancellation'
+      end
+
+      assert_raises(FiberCancellation) { dc.get('a') }
+
+      refute_predicate conn_mgr, :request_in_progress?,
+                       'double-exception in ensure left @request_in_progress == true'
+      refute_predicate conn_mgr, :connected?,
+                       'double-exception in ensure left @sock non-nil'
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to #68. Closes a second state-leak pathway on the same fiber-cancellation theme: when a non-StandardError (e.g. `Async::Stop`) is fired into a fiber that's already unwinding through Dalli's cleanup, it can escape `@sock.close` and leave the client in a dirty state that gets returned to the connection pool.

## The bug

With #68 merged, `Base#request` now calls `close` from an `ensure` when a non-StandardError aborts a request. That fix is correct — but `ConnectionManager#close` is itself not fully hardened against non-StandardError escapes:

```ruby
def close
  return unless @sock

  begin
    @sock.close
  rescue StandardError   # ← only StandardError
    nil
  end
  @sock = nil            # ← skipped if @sock.close raises non-StandardError
  @pid = nil             # ← skipped
  abort_request!         # ← skipped
end
```

If the scheduler fires a second `Async::Stop` into the fiber while it's inside this cleanup (e.g. a timeout that triggers cancellation of already-cancelling work), `@sock.close` can raise a non-StandardError. The `rescue StandardError` doesn't catch it, the three post-lines never run, and the exception propagates. The client goes back to the `ConnectionPool` with `@request_in_progress == true` and `@sock` still pointing at a half-closed FD.

The next fiber that checks out the client hits `confirm_ready!` → `close if request_in_progress?`, which attempts the same close. If *that* is also interrupted, the dirty-client reuse loops until the scheduler stops re-cancelling — during which window cross-response byte pollution on the socket is possible, matching the production symptom of "reads occasionally returning unexpected data."

## The fix

Move the state reset into an `ensure`, so `@sock = nil` / `@pid = nil` / `abort_request!` always run regardless of what `@sock.close` raises. The non-StandardError continues to propagate (we don't widen the rescue), so callers still see the cancellation.

```ruby
def close
  return unless @sock

  begin
    @sock.close
  rescue StandardError
    nil
  ensure
    @sock = nil
    @pid = nil
    abort_request!
  end
end
```

## Test

`test/integration/test_fiber_concurrency.rb` grows a second case that:
1. Warms the connection via `dc.set`
2. Overrides `@sock.close` to raise `FiberCancellation` (Exception subclass, stand-in for `Async::Stop`)
3. Overrides `read_line` to raise `FiberCancellation` (first cancellation, triggers the ensure path from #68)
4. Asserts the client is not `request_in_progress?` and not `connected?` after the double-exception unwinds

Verified the test fails on main (pre-fix) with the exact state leak this PR targets:
> `@request_in_progress=true, @sock=#<Dalli::Socket::TCP:fd 7>`

and passes with the `ensure` applied.

## Test plan
- [x] New test reproduces the leak pre-fix and passes post-fix
- [x] Existing fiber cancellation test from #68 still passes
- [x] `bundle exec rake test` passes
- [x] `bundle exec rubocop` clean