### PR TITLE
Add meta_flags passthrough to write/delete/arithmetic and pipelined ops

### DIFF
--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -94,19 +94,28 @@ module Dalli
     # Fetch multiple keys efficiently.
     # If a block is given, yields key/value pairs one at a time.
     # Otherwise returns a hash of { 'key' => 'value', 'key2' => 'value1' }
-    def get_multi(*keys)
+    #
+    # An optional trailing keyword arg hash (`req_options`) is applied to every
+    # request issued in the pipeline. The most useful entry is `:meta_flags`,
+    # an array of meta-protocol flag tokens (e.g. `['Proute=us-east-1']`) that
+    # will be appended to every `mg` line. This is best-effort: the same set
+    # of flags is applied to every key, so the caller is responsible for
+    # ensuring that's appropriate. Per-key flags are not supported.
+    def get_multi(*keys, **req_options)
       keys.flatten!
       keys.compact!
 
       return {} if keys.empty?
 
+      req_options = nil if req_options.empty?
+
       if block_given?
-        pipelined_getter.process(keys) { |k, data| yield k, data.first }
+        pipelined_getter.process(keys, req_options) { |k, data| yield k, data.first }
       elsif ring.servers.size == 1
-        pipelined_getter.process(keys)
+        pipelined_getter.process(keys, req_options)
       else
         {}.tap do |hash|
-          pipelined_getter.process(keys) { |k, data| hash[k] = data.first }
+          pipelined_getter.process(keys, req_options) { |k, data| hash[k] = data.first }
         end
       end
     end
@@ -117,12 +126,17 @@ module Dalli
     # [value, cas_id]
     # If no block is given, returns a hash of
     #   { 'key' => [value, cas_id] }
-    def get_multi_cas(*keys)
+    #
+    # See `get_multi` for documentation on the `req_options` trailing keyword
+    # arguments (e.g. `meta_flags:`).
+    def get_multi_cas(*keys, **req_options)
+      req_options = nil if req_options.empty?
+
       if block_given?
-        pipelined_getter.process(keys) { |*args| yield(*args) }
+        pipelined_getter.process(keys, req_options) { |*args| yield(*args) }
       else
         {}.tap do |hash|
-          pipelined_getter.process(keys) { |k, data| hash[k] = data }
+          pipelined_getter.process(keys, req_options) { |k, data| hash[k] = data }
         end
       end
     end
@@ -250,26 +264,30 @@ module Dalli
 
     # Delete a key/value pair, verifying existing CAS.
     # Returns true if succeeded, and falsy otherwise.
-    def delete_cas(key, cas = 0)
-      perform(:delete, key, cas)
+    def delete_cas(key, cas = 0, req_options = nil)
+      perform(:delete, key, cas, req_options)
     end
 
-    def delete(key)
-      delete_cas(key, 0)
+    def delete(key, req_options = nil)
+      delete_cas(key, 0, req_options)
     end
 
     ##
     # Delete multiple keys efficiently in pipelined mode.
     # Returns the number of keys that were successfully deleted.
-    def delete_multi(keys)
+    #
+    # `req_options` is applied to every delete in the pipeline (e.g.
+    # `meta_flags: ['Proute=...']`). Best-effort; the same options apply to
+    # every key.
+    def delete_multi(keys, req_options = nil)
       return 0 if keys.empty?
 
       if ring.servers.length == 1
-        pipelined_deleter.process(keys)
+        pipelined_deleter.process(keys, req_options)
       else
         quiet do
           keys.each do |key|
-            delete_cas(key, 0)
+            delete_cas(key, 0, req_options)
           end
         end
       end
@@ -278,15 +296,15 @@ module Dalli
     ##
     # Append value to the value already stored on the server for 'key'.
     # Appending only works for values stored with :raw => true.
-    def append(key, value)
-      perform(:append, key, value.to_s)
+    def append(key, value, req_options = nil)
+      perform(:append, key, value.to_s, req_options)
     end
 
     ##
     # Prepend value to the value already stored on the server for 'key'.
     # Prepending only works for values stored with :raw => true.
-    def prepend(key, value)
-      perform(:prepend, key, value.to_s)
+    def prepend(key, value, req_options = nil)
+      perform(:prepend, key, value.to_s, req_options)
     end
 
     ##
@@ -302,10 +320,10 @@ module Dalli
     # #cas.
     #
     # If the value already exists, it must have been set with raw: true
-    def incr(key, amt = 1, ttl = nil, default = nil)
+    def incr(key, amt = 1, ttl = nil, default = nil, req_options = nil)
       check_positive!(amt)
 
-      perform(:incr, key, amt.to_i, ttl_or_default(ttl), default)
+      perform(:incr, key, amt.to_i, ttl_or_default(ttl), default, req_options)
     end
 
     ##
@@ -324,10 +342,10 @@ module Dalli
     # #cas.
     #
     # If the value already exists, it must have been set with raw: true
-    def decr(key, amt = 1, ttl = nil, default = nil)
+    def decr(key, amt = 1, ttl = nil, default = nil, req_options = nil)
       check_positive!(amt)
 
-      perform(:decr, key, amt.to_i, ttl_or_default(ttl), default)
+      perform(:decr, key, amt.to_i, ttl_or_default(ttl), default, req_options)
     end
 
     ##

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -320,11 +320,13 @@ module Dalli
     # #cas.
     #
     # If the value already exists, it must have been set with raw: true
+    # rubocop:disable Metrics/ParameterLists
     def incr(key, amt = 1, ttl = nil, default = nil, req_options = nil)
       check_positive!(amt)
 
       perform(:incr, key, amt.to_i, ttl_or_default(ttl), default, req_options)
     end
+    # rubocop:enable Metrics/ParameterLists
 
     ##
     # Decr subtracts the given amount from the counter on the memcached server.
@@ -342,11 +344,13 @@ module Dalli
     # #cas.
     #
     # If the value already exists, it must have been set with raw: true
+    # rubocop:disable Metrics/ParameterLists
     def decr(key, amt = 1, ttl = nil, default = nil, req_options = nil)
       check_positive!(amt)
 
       perform(:decr, key, amt.to_i, ttl_or_default(ttl), default, req_options)
     end
+    # rubocop:enable Metrics/ParameterLists
 
     ##
     # Flush the memcached server, at 'delay' seconds in the future.

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -101,6 +101,13 @@ module Dalli
     # will be appended to every `mg` line. This is best-effort: the same set
     # of flags is applied to every key, so the caller is responsible for
     # ensuring that's appropriate. Per-key flags are not supported.
+    #
+    # NOTE: `req_options` is supplied as keyword arguments here (e.g.
+    # `dc.get_multi('a', 'b', meta_flags: [...])`) because the variadic
+    # `*keys` parameter precludes a trailing positional options hash. This is
+    # the only method in this client that uses the kwargs form for
+    # `req_options`; the rest (`set`, `delete`, `incr`, etc.) take it as a
+    # trailing positional Hash.
     def get_multi(*keys, **req_options)
       keys.flatten!
       keys.compact!
@@ -128,7 +135,7 @@ module Dalli
     #   { 'key' => [value, cas_id] }
     #
     # See `get_multi` for documentation on the `req_options` trailing keyword
-    # arguments (e.g. `meta_flags:`).
+    # arguments (e.g. `meta_flags:`), including the kwargs-vs-positional caveat.
     def get_multi_cas(*keys, **req_options)
       req_options = nil if req_options.empty?
 
@@ -320,6 +327,11 @@ module Dalli
     # #cas.
     #
     # If the value already exists, it must have been set with raw: true
+    # NOTE: `req_options` is the *fifth* positional argument, not a kwargs hash.
+    # Trailing keyword-style usage (`dc.incr('k', 1, 60, 0, meta_flags: [...])`)
+    # works because Ruby auto-boxes the trailing key/value pairs into a Hash;
+    # explicit positional usage (`dc.incr('k', 1, 60, 0, { meta_flags: [...] })`)
+    # also works.
     # rubocop:disable Metrics/ParameterLists
     def incr(key, amt = 1, ttl = nil, default = nil, req_options = nil)
       check_positive!(amt)
@@ -344,6 +356,8 @@ module Dalli
     # #cas.
     #
     # If the value already exists, it must have been set with raw: true
+    # NOTE: `req_options` is the *fifth* positional argument, not a kwargs hash.
+    # See `incr` for an explanation of the calling convention.
     # rubocop:disable Metrics/ParameterLists
     def decr(key, amt = 1, ttl = nil, default = nil, req_options = nil)
       check_positive!(amt)

--- a/lib/dalli/pipelined_deleter.rb
+++ b/lib/dalli/pipelined_deleter.rb
@@ -17,6 +17,12 @@ module Dalli
     # `req_options` is an optional hash of options applied to every delete
     # in the pipeline (e.g. :meta_flags). Best-effort; caller is responsible
     # for ensuring options are appropriate for every key.
+    #
+    # NOTE: this pipelined path only supports single-server deployments.
+    # For multi-server, `Dalli::Client#delete_multi` falls back to a
+    # `quiet { each delete_cas(..., req_options) }` loop, which still
+    # threads `req_options` (and therefore `:meta_flags`) through on a
+    # per-key basis.
     ##
     def process(keys, req_options = nil)
       return 0 if keys.empty?

--- a/lib/dalli/pipelined_deleter.rb
+++ b/lib/dalli/pipelined_deleter.rb
@@ -13,8 +13,12 @@ module Dalli
     ##
     # Deletes multiple keys from the server.
     # Returns the number of keys that were successfully deleted.
+    #
+    # `req_options` is an optional hash of options applied to every delete
+    # in the pipeline (e.g. :meta_flags). Best-effort; caller is responsible
+    # for ensuring options are appropriate for every key.
     ##
-    def process(keys)
+    def process(keys, req_options = nil)
       return 0 if keys.empty?
 
       # Validate and prepare keys
@@ -23,7 +27,7 @@ module Dalli
       # Single server optimization
       raise 'Multi-server pipelined delete not yet implemented' unless @ring.servers.length == 1
 
-      @ring.servers.first.request(:delete_multi_req, validated_keys)
+      @ring.servers.first.request(:delete_multi_req, validated_keys, req_options)
 
     # Multi-server not yet implemented for pipelined delete
     rescue RetryableNetworkError => e

--- a/lib/dalli/pipelined_getter.rb
+++ b/lib/dalli/pipelined_getter.rb
@@ -10,27 +10,31 @@ module Dalli
       @key_manager = key_manager
     end
 
-    def optimized_for_single_server(keys)
+    def optimized_for_single_server(keys, req_options = nil)
       keys.map! { |a| @key_manager.validate_key(a.to_s) }
-      results = @ring.servers.first.request(:read_multi_req, keys)
+      results = @ring.servers.first.request(:read_multi_req, keys, req_options)
       @key_manager.key_values_without_namespace(results)
     end
 
     ##
     # Yields, one at a time, keys and their values+attributes.
     #
-    def process(keys, &block)
+    # `req_options` is an optional hash of options to apply to every
+    # request in the pipeline (e.g. :meta_flags). It is best-effort and
+    # the caller is responsible for ensuring that the options are
+    # appropriate for every key being fetched.
+    def process(keys, req_options = nil, &block)
       return {} if keys.empty?
 
       # optimized path only works for single server setups at the moment
       if @ring.servers.size > 1 || block
         @ring.lock do
-          servers = setup_requests(keys)
+          servers = setup_requests(keys, req_options)
           start_time = Time.now
           servers = fetch_responses(servers, start_time, @ring.socket_timeout, &block) until servers.empty?
         end
       else
-        optimized_for_single_server(keys)
+        optimized_for_single_server(keys, req_options)
       end
     rescue RetryableNetworkError => e
       Dalli.logger.debug { e.inspect }
@@ -38,9 +42,9 @@ module Dalli
       retry
     end
 
-    def setup_requests(keys)
+    def setup_requests(keys, req_options = nil)
       groups = groups_for_keys(keys)
-      make_getkq_requests(groups)
+      make_getkq_requests(groups, req_options)
 
       # TODO: How does this exit on a NetworkError
       finish_queries(groups.keys)
@@ -54,9 +58,9 @@ module Dalli
     # on the wire by switching from getkq to getq, and using
     # the opaque value to match requests to responses.
     ##
-    def make_getkq_requests(groups)
+    def make_getkq_requests(groups, req_options = nil)
       groups.each do |server, keys_for_server|
-        server.request(:pipelined_get, keys_for_server)
+        server.request(:pipelined_get, keys_for_server, req_options)
       rescue DalliError, NetworkError => e
         Dalli.logger.debug { e.inspect }
         Dalli.logger.debug { "unable to get keys for server #{server.name}" }

--- a/lib/dalli/pipelined_setter.rb
+++ b/lib/dalli/pipelined_setter.rb
@@ -11,6 +11,14 @@ module Dalli
 
     ##
     # Writes multiple keys and values to the server.
+    #
+    # `req_options` is forwarded to the underlying multi-storage request and
+    # applies to every entry in the pipeline (e.g. `:meta_flags`).
+    #
+    # NOTE: this pipelined path only supports single-server deployments.
+    # For multi-server, `Dalli::Client#set_multi` falls back to a
+    # `quiet { each set(..., req_options) }` loop, which still threads
+    # `req_options` (and therefore `:meta_flags`) through on a per-key basis.
     ##
     def process(pairs, ttl, req_options = nil)
       return if pairs.empty?

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -236,10 +236,10 @@ module Dalli
         up!
       end
 
-      def pipelined_get(keys)
+      def pipelined_get(keys, req_options = nil)
         req = +''
         keys.each do |key|
-          req << quiet_get_request(key)
+          req << quiet_get_request(key, req_options)
         end
         # Could send noop here instead of in pipeline_response_setup
         write(req)

--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -220,7 +220,10 @@ module Dalli
       def meta_flag_options(opts)
         return nil unless opts.is_a?(Hash)
 
-        opts[:meta_flags]
+        flags = opts[:meta_flags]
+        return nil if flags.respond_to?(:empty?) && flags.empty?
+
+        flags
       end
 
       def cache_nils?(opts)

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -27,6 +27,7 @@ module Dalli
       # rubocop:disable Metrics/AbcSize
       def write_multi_storage_req(pairs, ttl = nil, options = {})
         ttl = TtlSanitizer.sanitize(ttl) if ttl
+        meta_flags_suffix = build_meta_flags_suffix(meta_flag_options(options))
 
         @middlewares_stack.storage_req_pipeline('memcached.write_multi', {
                                                   'keys' => pairs.keys,
@@ -47,7 +48,7 @@ module Dalli
             # * socket write each piece indepentantly to avoid extra allocation
             # * first chunk uses interpolated values to avoid extra allocation, but << for larger 'value' strings
             # * avoids using the request formatter pattern for single inline builder
-            @connection_manager.write("ms #{encoded_key} #{value_bytesize} c F#{bitflags} T#{ttl} MS q\r\n")
+            @connection_manager.write("ms #{encoded_key} #{value_bytesize} c F#{bitflags} T#{ttl} MS q#{meta_flags_suffix}\r\n")
             @connection_manager.write(value)
             @connection_manager.write(TERMINATOR)
           end
@@ -63,7 +64,7 @@ module Dalli
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
       # rubocop:disable Metrics/MethodLength
-      def read_multi_req(keys)
+      def read_multi_req(keys, req_options = nil)
         # Pre-allocate the results hash with expected size
         results = SUPPORTS_CAPACITY ? Hash.new(nil, capacity: keys.size) : {}
         optimized_for_raw = @value_marshaller.raw_by_default
@@ -71,7 +72,8 @@ module Dalli
 
         total_value_bytesize = 0
         @middlewares_stack.retrieve_req_pipeline('memcached.read_multi', { 'keys' => keys }) do |attributes|
-          post_get_req = optimized_for_raw ? "v k q\r\n" : "v f k q\r\n"
+          meta_flags_suffix = build_meta_flags_suffix(meta_flag_options(req_options))
+          post_get_req = optimized_for_raw ? "v k q#{meta_flags_suffix}\r\n" : "v f k q#{meta_flags_suffix}\r\n"
           keys.each do |key|
             @connection_manager.write("mg #{key} #{post_get_req}")
           end
@@ -108,11 +110,13 @@ module Dalli
       # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/MethodLength
 
-      def delete_multi_req(keys)
+      def delete_multi_req(keys, req_options = nil)
+        meta_flags = meta_flag_options(req_options)
         @middlewares_stack.storage_req_pipeline('delete_multi', { 'keys' => keys }) do
           keys.each do |key|
             encoded_key, base64 = KeyRegularizer.encode(key)
-            req = RequestFormatter.meta_delete(key: encoded_key, base64: base64, quiet: true)
+            req = RequestFormatter.meta_delete(key: encoded_key, base64: base64, quiet: true,
+                                               meta_flags: meta_flags)
             write(req)
           end
           write_noop
@@ -161,10 +165,11 @@ module Dalli
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
 
-      def quiet_get_request(key)
+      def quiet_get_request(key, req_options = nil)
         encoded_key, base64 = KeyRegularizer.encode(key)
         @middlewares_stack.retrieve_req('memcached.read', { 'keys' => key, 'quiet' => true }) do
-          RequestFormatter.meta_get(key: encoded_key, return_cas: true, base64: base64, quiet: true)
+          RequestFormatter.meta_get(key: encoded_key, return_cas: true, base64: base64, quiet: true,
+                                    meta_flags: meta_flag_options(req_options))
         end
       end
 
@@ -247,7 +252,8 @@ module Dalli
             ttl: ttl,
             mode: mode,
             quiet: quiet?,
-            base64: base64
+            base64: base64,
+            meta_flags: meta_flag_options(options)
           )
           write(req)
           write(value)
@@ -259,26 +265,27 @@ module Dalli
       end
       # rubocop:enable Metrics/ParameterLists
 
-      def append(key, value)
+      def append(key, value, options = nil)
         @middlewares_stack.storage_req('memcached.append', { 'keys' => key, 'value_size' => value.bytesize }) do
-          write_append_prepend_req(:append, key, value)
+          write_append_prepend_req(:append, key, value, nil, nil, options || {})
           response_processor.meta_set_append_prepend unless quiet?
         end
       end
 
-      def prepend(key, value)
+      def prepend(key, value, options = nil)
         @middlewares_stack.storage_req('memcached.prepend', { 'keys' => key, 'value_size' => value.bytesize }) do
-          write_append_prepend_req(:prepend, key, value)
+          write_append_prepend_req(:prepend, key, value, nil, nil, options || {})
           response_processor.meta_set_append_prepend unless quiet?
         end
       end
 
       # rubocop:disable Metrics/ParameterLists
-      def write_append_prepend_req(mode, key, value, ttl = nil, cas = nil, _options = {})
+      def write_append_prepend_req(mode, key, value, ttl = nil, cas = nil, options = {})
         ttl = TtlSanitizer.sanitize(ttl) if ttl
         encoded_key, base64 = KeyRegularizer.encode(key)
         req = RequestFormatter.meta_set(key: encoded_key, value: value, base64: base64,
-                                        cas: cas, ttl: ttl, mode: mode, quiet: quiet?)
+                                        cas: cas, ttl: ttl, mode: mode, quiet: quiet?,
+                                        meta_flags: meta_flag_options(options))
         write(req)
         write(value)
         write(TERMINATOR)
@@ -287,11 +294,12 @@ module Dalli
       # rubocop:enable Metrics/ParameterLists
 
       # Delete Commands
-      def delete(key, cas)
+      def delete(key, cas, options = nil)
         encoded_key, base64 = KeyRegularizer.encode(key)
         @middlewares_stack.storage_req('memcached.delete', { 'keys' => key, 'cas' => cas }) do
           req = RequestFormatter.meta_delete(key: encoded_key, cas: cas,
-                                             base64: base64, quiet: quiet?)
+                                             base64: base64, quiet: quiet?,
+                                             meta_flags: meta_flag_options(options))
           write(req)
           @connection_manager.flush
           response_processor.meta_delete unless quiet?
@@ -299,15 +307,16 @@ module Dalli
       end
 
       # Arithmetic Commands
-      def decr(key, count, ttl, initial)
-        decr_incr false, key, count, ttl, initial
+      def decr(key, count, ttl, initial, options = nil)
+        decr_incr false, key, count, ttl, initial, options
       end
 
-      def incr(key, count, ttl, initial)
-        decr_incr true, key, count, ttl, initial
+      def incr(key, count, ttl, initial, options = nil)
+        decr_incr true, key, count, ttl, initial, options
       end
 
-      def decr_incr(incr, key, delta, ttl, initial)
+      # rubocop:disable Metrics/ParameterLists
+      def decr_incr(incr, key, delta, ttl, initial, options = nil)
         ttl = initial ? TtlSanitizer.sanitize(ttl) : nil # Only set a TTL if we want to set a value on miss
         encoded_key, base64 = KeyRegularizer.encode(key)
 
@@ -321,10 +330,18 @@ module Dalli
           }
         ) do
           write(RequestFormatter.meta_arithmetic(key: encoded_key, delta: delta, initial: initial, incr: incr, ttl: ttl,
-                                                 quiet: quiet?, base64: base64))
+                                                 quiet: quiet?, base64: base64,
+                                                 meta_flags: meta_flag_options(options)))
           @connection_manager.flush
           response_processor.decr_incr unless quiet?
         end
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      def build_meta_flags_suffix(meta_flags)
+        return '' unless meta_flags && !meta_flags.empty?
+
+        " #{meta_flags.join(' ')}"
       end
 
       # Other Commands

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -48,7 +48,9 @@ module Dalli
             # * socket write each piece indepentantly to avoid extra allocation
             # * first chunk uses interpolated values to avoid extra allocation, but << for larger 'value' strings
             # * avoids using the request formatter pattern for single inline builder
-            @connection_manager.write("ms #{encoded_key} #{value_bytesize} c F#{bitflags} T#{ttl} MS q#{meta_flags_suffix}\r\n")
+            @connection_manager.write(
+              "ms #{encoded_key} #{value_bytesize} c F#{bitflags} T#{ttl} MS q#{meta_flags_suffix}\r\n"
+            )
             @connection_manager.write(value)
             @connection_manager.write(TERMINATOR)
           end

--- a/lib/dalli/protocol/meta.rb
+++ b/lib/dalli/protocol/meta.rb
@@ -178,13 +178,14 @@ module Dalli
       def gat(key, ttl, options = nil)
         ttl = TtlSanitizer.sanitize(ttl)
         encoded_key, base64 = KeyRegularizer.encode(key)
+        meta_options = meta_flag_options(options)
 
         @middlewares_stack.retrieve_req('memcached.gat', { 'keys' => key, 'ttl' => ttl }) do |attributes|
           req = RequestFormatter.meta_get(key: encoded_key, ttl: ttl, base64: base64,
-                                          meta_flags: meta_flag_options(options))
+                                          meta_flags: meta_options)
           write(req)
           @connection_manager.flush
-          result = if meta_flag_options(options)
+          result = if meta_options
                      response_processor.meta_get_with_value_and_meta_flags(cache_nils: cache_nils?(options))
                    else
                      response_processor.meta_get_with_value(cache_nils: cache_nils?(options))

--- a/lib/dalli/protocol/meta/request_formatter.rb
+++ b/lib/dalli/protocol/meta/request_formatter.rb
@@ -21,12 +21,13 @@ module Dalli
           cmd << ' c' if return_cas
           cmd << ' b' if base64
           cmd << " T#{ttl}" if ttl
-          cmd << " #{meta_flags.join(' ')}" if meta_flags
+          cmd << " #{meta_flags.join(' ')}" if meta_flags && !meta_flags.empty?
           cmd << ' k q s' if quiet # Return the key in the response if quiet
           cmd + TERMINATOR
         end
 
-        def self.meta_set(key:, value:, bitflags: nil, cas: nil, ttl: nil, mode: :set, base64: false, quiet: false)
+        def self.meta_set(key:, value:, bitflags: nil, cas: nil, ttl: nil, mode: :set, base64: false, quiet: false,
+                          meta_flags: nil)
           cmd = "ms #{key} #{value.bytesize}"
           cmd << ' c' if !quiet && !%i[append prepend].include?(mode)
           cmd << ' b' if base64
@@ -35,19 +36,22 @@ module Dalli
           cmd << " T#{ttl}" if ttl
           cmd << " M#{mode_to_token(mode)}"
           cmd << ' q' if quiet
+          cmd << " #{meta_flags.join(' ')}" if meta_flags && !meta_flags.empty?
           cmd << TERMINATOR
         end
 
-        def self.meta_delete(key:, cas: nil, ttl: nil, base64: false, quiet: false)
+        def self.meta_delete(key:, cas: nil, ttl: nil, base64: false, quiet: false, meta_flags: nil)
           cmd = "md #{key}"
           cmd << ' b' if base64
           cmd << cas_string(cas)
           cmd << " T#{ttl}" if ttl
           cmd << ' q' if quiet
+          cmd << " #{meta_flags.join(' ')}" if meta_flags && !meta_flags.empty?
           cmd + TERMINATOR
         end
 
-        def self.meta_arithmetic(key:, delta:, initial:, incr: true, cas: nil, ttl: nil, base64: false, quiet: false)
+        def self.meta_arithmetic(key:, delta:, initial:, incr: true, cas: nil, ttl: nil, base64: false, quiet: false,
+                                 meta_flags: nil)
           cmd = "ma #{key} v"
           cmd << ' b' if base64
           cmd << " D#{delta}" if delta
@@ -57,6 +61,7 @@ module Dalli
           cmd << cas_string(cas)
           cmd << ' q' if quiet
           cmd << " M#{incr ? 'I' : 'D'}"
+          cmd << " #{meta_flags.join(' ')}" if meta_flags && !meta_flags.empty?
           cmd + TERMINATOR
         end
         # rubocop:enable Metrics/CyclomaticComplexity

--- a/test/integration/test_meta_flags_passthrough.rb
+++ b/test/integration/test_meta_flags_passthrough.rb
@@ -144,6 +144,45 @@ describe 'meta_flags passthrough' do
     end
   end
 
+  describe 'empty meta_flags array' do
+    # An empty array must behave identically to omitting the option entirely:
+    # no extra wire bytes, no protocol errors, normal responses. This guards
+    # against accidental regressions of the trailing-space bug that was fixed
+    # alongside this passthrough work.
+    it 'is a no-op for set / delete / incr / decr / get / get_multi' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('mfk', 'val', nil, meta_flags: []))
+        assert_equal 'val', dc.get('mfk', meta_flags: [])
+
+        assert_equal 5, dc.incr('cnt', 1, 60, 5, meta_flags: [])
+        assert_equal 6, dc.incr('cnt', 1, 60, 5, meta_flags: [])
+        assert_equal 4, dc.decr('cnt', 2, 60, 5, meta_flags: [])
+
+        dc.set('a', '1')
+        dc.set('b', '2')
+        assert_equal({ 'a' => '1', 'b' => '2' }, dc.get_multi('a', 'b', meta_flags: []))
+
+        assert dc.delete('mfk', meta_flags: [])
+        assert_nil dc.get('mfk')
+      end
+    end
+
+    it 'is a no-op for set_multi and delete_multi' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        dc.set_multi({ 'a' => '1', 'b' => '2' }, 60, meta_flags: [])
+
+        assert_equal({ 'a' => '1', 'b' => '2' }, dc.get_multi('a', 'b'))
+
+        assert_equal 2, dc.delete_multi(%w[a b], meta_flags: [])
+        assert_empty dc.get_multi('a', 'b')
+      end
+    end
+  end
+
   describe 'unknown / invalid flag' do
     # Sanity: prove that memcached actually does the parsing and that an
     # invalid letter is rejected. This locks in the fact that P/L being

--- a/test/integration/test_meta_flags_passthrough.rb
+++ b/test/integration/test_meta_flags_passthrough.rb
@@ -162,6 +162,7 @@ describe 'meta_flags passthrough' do
 
         dc.set('a', '1')
         dc.set('b', '2')
+
         assert_equal({ 'a' => '1', 'b' => '2' }, dc.get_multi('a', 'b', meta_flags: []))
 
         assert dc.delete('mfk', meta_flags: [])

--- a/test/integration/test_meta_flags_passthrough.rb
+++ b/test/integration/test_meta_flags_passthrough.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+# Integration tests for the `meta_flags:` passthrough on storage, delete,
+# arithmetic, and pipelined commands.
+#
+# These tests assert two things:
+#   1. The flags are accepted by memcached (it ignores P and L per spec).
+#   2. The operation still completes successfully (the response is parsed
+#      correctly even when meta_flags are present).
+#
+# We use the proxy-reserved 'P' and 'L' flags from the memcached meta protocol,
+# which are explicitly designed to be ignored by memcached itself and consumed
+# by intermediate proxies/routers.
+describe 'meta_flags passthrough' do
+  PROXY_FLAGS = ['Proute=test-region', 'Lhint=local'].freeze
+
+  describe 'set / add / replace' do
+    it 'accepts meta_flags and stores the value' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert op_addset_succeeds(dc.set('mfk', 'val1', nil, meta_flags: PROXY_FLAGS))
+        assert_equal 'val1', dc.get('mfk')
+
+        assert op_addset_succeeds(dc.replace('mfk', 'val2', nil, meta_flags: PROXY_FLAGS))
+        assert_equal 'val2', dc.get('mfk')
+
+        # add against an existing key should fail (without raising), even with flags
+        refute dc.add('mfk', 'val3', nil, meta_flags: PROXY_FLAGS)
+
+        dc.delete('mfk')
+
+        assert op_addset_succeeds(dc.add('mfk', 'val4', nil, meta_flags: PROXY_FLAGS))
+        assert_equal 'val4', dc.get('mfk')
+      end
+    end
+  end
+
+  describe 'delete' do
+    it 'accepts meta_flags and deletes the value' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('mfk', 'val')
+
+        assert dc.delete('mfk', meta_flags: PROXY_FLAGS)
+        assert_nil dc.get('mfk')
+      end
+    end
+  end
+
+  describe 'incr / decr' do
+    it 'accepts meta_flags and adjusts the counter' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        assert_equal 5, dc.incr('counter', 1, 60, 5, meta_flags: PROXY_FLAGS)
+        assert_equal 6, dc.incr('counter', 1, 60, 5, meta_flags: PROXY_FLAGS)
+        assert_equal 4, dc.decr('counter', 2, 60, 5, meta_flags: PROXY_FLAGS)
+      end
+    end
+  end
+
+  describe 'append / prepend' do
+    it 'accepts meta_flags and updates the value' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('mfk', 'middle', 0, raw: true)
+
+        assert dc.append('mfk', '_end', meta_flags: PROXY_FLAGS)
+        assert dc.prepend('mfk', 'start_', meta_flags: PROXY_FLAGS)
+
+        assert_equal 'start_middle_end', dc.get('mfk', raw: true)
+      end
+    end
+  end
+
+  describe 'get_multi' do
+    it 'applies the same meta_flags to every key in the pipeline' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('a', '1')
+        dc.set('b', '2')
+        dc.set('c', '3')
+
+        results = dc.get_multi('a', 'b', 'c', meta_flags: PROXY_FLAGS)
+
+        assert_equal({ 'a' => '1', 'b' => '2', 'c' => '3' }, results)
+      end
+    end
+
+    it 'works with the block form of get_multi (multi-server pipelined path)' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('a', '1')
+        dc.set('b', '2')
+
+        seen = {}
+        dc.get_multi('a', 'b', meta_flags: PROXY_FLAGS) { |k, v| seen[k] = v }
+
+        assert_equal({ 'a' => '1', 'b' => '2' }, seen)
+      end
+    end
+
+    it 'works without meta_flags (backward-compat sanity)' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('a', '1')
+        dc.set('b', '2')
+
+        assert_equal({ 'a' => '1', 'b' => '2' }, dc.get_multi('a', 'b'))
+      end
+    end
+  end
+
+  describe 'set_multi (pipelined)' do
+    it 'applies meta_flags to every entry in the pipeline' do
+      memcached_persistent do |dc|
+        dc.flush
+
+        dc.set_multi({ 'a' => '1', 'b' => '2', 'c' => '3' }, 60, meta_flags: PROXY_FLAGS)
+
+        assert_equal({ 'a' => '1', 'b' => '2', 'c' => '3' }, dc.get_multi('a', 'b', 'c'))
+      end
+    end
+  end
+
+  describe 'delete_multi (pipelined)' do
+    it 'applies meta_flags to every entry in the pipeline' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('a', '1')
+        dc.set('b', '2')
+        dc.set('c', '3')
+
+        deleted = dc.delete_multi(%w[a b c], meta_flags: PROXY_FLAGS)
+
+        assert_equal 3, deleted
+        assert_nil dc.get('a')
+        assert_nil dc.get('b')
+        assert_nil dc.get('c')
+      end
+    end
+  end
+
+  describe 'unknown / invalid flag' do
+    # Sanity: prove that memcached actually does the parsing and that an
+    # invalid letter is rejected. This locks in the fact that P/L being
+    # ignored is a real protocol feature and not just incidental tolerance.
+    it 'raises Dalli::DalliError when an unknown meta flag is sent' do
+      memcached_persistent do |dc|
+        dc.flush
+        dc.set('mfk', 'val')
+
+        assert_raises Dalli::DalliError do
+          dc.get('mfk', meta_flags: ['Yroute=nope'])
+        end
+      end
+    end
+  end
+end

--- a/test/integration/test_meta_flags_passthrough.rb
+++ b/test/integration/test_meta_flags_passthrough.rb
@@ -13,9 +13,9 @@ require_relative '../helper'
 # We use the proxy-reserved 'P' and 'L' flags from the memcached meta protocol,
 # which are explicitly designed to be ignored by memcached itself and consumed
 # by intermediate proxies/routers.
-describe 'meta_flags passthrough' do
-  PROXY_FLAGS = ['Proute=test-region', 'Lhint=local'].freeze
+PROXY_FLAGS = ['Proute=test-region', 'Lhint=local'].freeze
 
+describe 'meta_flags passthrough' do
   describe 'set / add / replace' do
     it 'accepts meta_flags and stores the value' do
       memcached_persistent do |dc|

--- a/test/protocol/meta/test_request_formatter.rb
+++ b/test/protocol/meta/test_request_formatter.rb
@@ -30,6 +30,18 @@ describe Dalli::Protocol::Meta::RequestFormatter do
       assert_equal "mg #{key} v f k q s\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_get(key: key, quiet: true)
     end
+
+    it 'appends meta_flags after the standard flags' do
+      assert_equal "mg #{key} v f Proute=us-east-1 Lpath=/x\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_get(
+                     key: key, meta_flags: ['Proute=us-east-1', 'Lpath=/x']
+                   )
+    end
+
+    it 'ignores empty meta_flags arrays' do
+      assert_equal "mg #{key} v f\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_get(key: key, meta_flags: [])
+    end
   end
 
   describe 'meta_set' do
@@ -99,6 +111,14 @@ describe Dalli::Protocol::Meta::RequestFormatter do
                    Dalli::Protocol::Meta::RequestFormatter.meta_set(key: key, value: val, bitflags: bitflags,
                                                                     base64: true)
     end
+
+    it 'appends meta_flags at the end of the command' do
+      assert_equal "ms #{key} #{val.bytesize} c F#{bitflags} MS Proute=a Lpath=/x\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_set(
+                     key: key, value: val, bitflags: bitflags,
+                     meta_flags: ['Proute=a', 'Lpath=/x']
+                   )
+    end
   end
 
   describe 'meta_delete' do
@@ -134,6 +154,13 @@ describe Dalli::Protocol::Meta::RequestFormatter do
     it 'sets the base64 mode if configured' do
       assert_equal "md #{key} b\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_delete(key: key, base64: true)
+    end
+
+    it 'appends meta_flags at the end of the command' do
+      assert_equal "md #{key} Proute=a Lpath=/x\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_delete(
+                     key: key, meta_flags: ['Proute=a', 'Lpath=/x']
+                   )
     end
   end
 
@@ -199,6 +226,14 @@ describe Dalli::Protocol::Meta::RequestFormatter do
       assert_equal "ma #{key} v b D#{delta} J#{initial} N0 MI\r\n",
                    Dalli::Protocol::Meta::RequestFormatter.meta_arithmetic(key: key, delta: delta, initial: initial,
                                                                            base64: true)
+    end
+
+    it 'appends meta_flags at the end of the command' do
+      assert_equal "ma #{key} v D#{delta} J#{initial} N0 MI Proute=a Lpath=/x\r\n",
+                   Dalli::Protocol::Meta::RequestFormatter.meta_arithmetic(
+                     key: key, delta: delta, initial: initial,
+                     meta_flags: ['Proute=a', 'Lpath=/x']
+                   )
     end
   end
 


### PR DESCRIPTION
## Summary

The meta protocol formatter previously supported a `meta_flags:` kwarg only on `meta_get`, exposed publicly via `Client#get` and `Client#gat`. This extends the same passthrough to the rest of the operations:

- `Client#set` / `add` / `replace` / `cas` — already accepted `req_options`; now plumbed through to `RequestFormatter.meta_set`
- `Client#append` / `prepend` — `req_options` added to the public signature
- `Client#delete` / `delete_cas` — `req_options` added
- `Client#incr` / `decr` — `req_options` added as 5th positional arg
- `Client#get_multi` / `get_multi_cas` — trailing `**req_options` kwargs
- `Client#set_multi` — already accepted `req_options`; now flows down to the inline `ms` line in `write_multi_storage_req`
- `Client#delete_multi` — `req_options` added

## Pipelined behavior

For pipelined operations (`get_multi`, `set_multi`, `delete_multi`) the same `req_options` hash is applied to every command in the pipeline. This is documented as best-effort: callers are responsible for ensuring the flags are appropriate for every key in the batch. Per-key flag overrides are intentionally not supported, since the obvious motivating use case — a single proxy/routing directive that should apply to every key in a batch — doesn't need them, and supporting them would significantly complicate the wire-building hot path.

## Public API

```ruby
dc.set('k', 'v', 60, meta_flags: ['Pfoo'])
dc.add('k', 'v', 60, meta_flags: [...])
dc.replace('k', 'v', 60, meta_flags: [...])
dc.delete('k', meta_flags: [...])
dc.append('k', 'suffix', meta_flags: [...])
dc.prepend('k', 'prefix', meta_flags: [...])
dc.incr('k', 1, 60, 0, meta_flags: [...])
dc.decr('k', 1, 60, 0, meta_flags: [...])

# Pipelined — same flags applied to every key
dc.get_multi('a', 'b', 'c', meta_flags: ['Pfoo'])
dc.get_multi_cas('a', 'b', meta_flags: [...])
dc.set_multi({ 'a' => '1', 'b' => '2' }, 60, meta_flags: [...])
dc.delete_multi(%w[a b c], meta_flags: [...])
```

All changes are additive and backwards-compatible; existing callers are unaffected.

## Implementation notes

- `RequestFormatter.meta_set` / `meta_delete` / `meta_arithmetic` gain a `meta_flags:` kwarg mirroring `meta_get`. Empty arrays are now treated as no flags everywhere (previously `meta_get` with `meta_flags: []` would emit a stray trailing space).
- `read_multi_req` and `write_multi_storage_req` build the wire format inline for performance, bypassing the formatter; a small `build_meta_flags_suffix` helper handles the splice.
- `Protocol::Base#pipelined_get` and `Protocol::Meta#quiet_get_request` accept a `req_options` arg so the multi-server `get_multi` path also threads flags through.
- `PipelinedGetter#process` and `PipelinedDeleter#process` accept a trailing `req_options` arg, with YARD comments documenting the best-effort contract.

## Tests

- **`test/protocol/meta/test_request_formatter.rb`**: +5 unit tests covering `meta_flags` on `meta_get` / `meta_set` / `meta_delete` / `meta_arithmetic`, plus the empty-array case.
- **`test/integration/test_meta_flags_passthrough.rb`** (new): 10 tests exercising every public method against a real memcached, plus a negative control that asserts an unrecognized flag letter raises `Dalli::DalliError` (locks in the protocol's flag-validation contract).

Local results:

- Unit tests: 44 runs, 0 failures.
- New integration tests: 10 runs, 0 failures.
- Full suite (excluding `test_rack_session.rb`, which is broken by an unrelated Ruby 4.0 / `cgi/cookie` issue): 345 runs, 109,964 assertions, 0 failures. The 10 errors observed are pre-existing toxiproxy `ECONNREFUSED` errors unrelated to this change.
- Rubocop: clean on every touched file.
