### PR TITLE
Use local flag instead of $ERROR_INFO to gate ensure-block close

### DIFF
--- a/lib/dalli/protocol/base.rb
+++ b/lib/dalli/protocol/base.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'English'
 require 'forwardable'
 require 'socket'
 require 'timeout'
@@ -44,12 +43,14 @@ module Dalli
         verify_state(opkey)
 
         begin
+          request_local_completed = false
           @connection_manager.start_request!
           response = send(opkey, *args)
 
           # pipelined_get emit query but doesn't read the response(s)
           @connection_manager.finish_request! unless opkey == :pipelined_get
 
+          request_local_completed = true
           response
         rescue Dalli::MarshalError => e
           log_marshal_err(args.first, e)
@@ -61,12 +62,15 @@ module Dalli
           close
           raise
         ensure
-          # Catches non-StandardError exceptions (e.g. Async::Stop) that sail
-          # past the rescues above.  $ERROR_INFO is non-nil only when an
-          # exception is unwinding, so pipelined_get's happy path — which
-          # intentionally leaves @request_in_progress = true until the
-          # caller drains the responses — isn't torn down.
-          close if $ERROR_INFO && @connection_manager.request_in_progress?
+          # If the begin block didn't complete — any exception, including
+          # non-StandardError like Async::Stop — tear down the connection
+          # so we don't return a half-used client to the pool.  The local
+          # flag avoids reading $ERROR_INFO, which leaks state when
+          # `request` is called from inside a rescue clause: $! is preserved
+          # there and would falsely trigger close on the pipelined_get
+          # happy path (which intentionally leaves @request_in_progress
+          # true until the caller drains the responses).
+          close unless request_local_completed
         end
       end
 

--- a/test/integration/test_fiber_concurrency.rb
+++ b/test/integration/test_fiber_concurrency.rb
@@ -19,10 +19,10 @@ describe 'fiber concurrency' do
   # and any partial response bytes remain on the wire for a subsequent caller
   # to misread.
   #
-  # `Base#request` gates its `ensure` on `$ERROR_INFO` so that pipelined_get's
-  # intentional request_in_progress=true happy path is not torn down — this
-  # test proves the cleanup fires on abnormal exit for non-StandardError
-  # exceptions.
+  # `Base#request` gates its `ensure` on a local `request_local_completed`
+  # flag so that pipelined_get's intentional request_in_progress=true happy
+  # path is not torn down — this test proves the cleanup fires on abnormal
+  # exit for non-StandardError exceptions.
   #
   # NOTE: this test uses the default `threadsafe: true` config.  The yield-
   # based interleave race (one fiber parking on IO while another enters
@@ -90,6 +90,53 @@ describe 'fiber concurrency' do
                        'double-exception in ensure left @request_in_progress == true'
       refute_predicate conn_mgr, :connected?,
                        'double-exception in ensure left @sock non-nil'
+    end
+  end
+
+  # `$!` (a.k.a. $ERROR_INFO) is preserved when a method is called from
+  # inside a `rescue` clause.  An ensure clause that reads $! to decide
+  # whether "we're unwinding from an exception" sees the *outer* rescued
+  # exception even when its own begin block completed cleanly.
+  #
+  # On the pipelined_get happy path, @request_in_progress is intentionally
+  # left true (the caller still has to drain).  An ensure that closes when
+  # `$ERROR_INFO && request_in_progress?` would therefore tear the socket
+  # out from under a pipelined_get whenever it's called from inside any
+  # rescue clause — a common cache-fallback pattern.  This test pins the
+  # local-flag implementation by exercising that exact call shape.
+  #
+  # NOTE: a block is required here.  Without one, single-server get_multi
+  # takes the `optimized_for_single_server` path which uses :read_multi_req
+  # (calls finish_request!) and would not exercise the pipelined_get
+  # ensure-close window.  Passing a block forces the :pipelined_get opkey.
+  it 'does not tear down a pipelined_get when called from inside a rescue clause' do
+    memcached_persistent do |dc|
+      dc.flush
+      dc.set('a', 'val_a')
+      dc.set('b', 'val_b')
+
+      conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+
+      close_count = 0
+      orig_close = conn_mgr.method(:close)
+      conn_mgr.define_singleton_method(:close) do
+        close_count += 1
+        orig_close.call
+      end
+
+      result = {}
+      begin
+        raise 'outer rescued exception'
+      rescue StandardError
+        # $! is set to the rescued exception while this block executes,
+        # including across the get_multi call.  Block forces :pipelined_get.
+        dc.get_multi(%w[a b]) { |k, v| result[k] = v }
+      end
+
+      assert_equal({ 'a' => 'val_a', 'b' => 'val_b' }, result)
+      assert_equal 0, close_count,
+                   "pipelined_get was torn down mid-flight (close_count=#{close_count}) " \
+                   'when called from inside a rescue clause'
     end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #68 and #69. Fixes a real production-symptom-matching bug where `dc.get_multi(...) { … }` (and any pipelined_get) called from inside a `rescue` clause silently returns `{}` instead of the expected results, because `Base#request`'s ensure was reading `$ERROR_INFO` (a.k.a. `$!`) — which is preserved into nested method calls when the call is made from a rescue handler.

## The bug

Old ensure:

```ruby
ensure
  close if $ERROR_INFO && @connection_manager.request_in_progress?
end
```

`$!` is set during a rescue clause and stays set across method calls made from inside that clause. So when application code does the very common cache-fallback pattern:

```ruby
begin
  primary_lookup
rescue StandardError
  cache.get_multi(keys) { |k, v| … }   # passes through Base#request(:pipelined_get, …)
end
```

…inside `Base#request`'s ensure:

- `$ERROR_INFO` is the *outer* rescued exception (truthy)
- `request_in_progress?` is `true` because `:pipelined_get` intentionally skips `finish_request!` (the caller still has to drain responses)

Both conditions met → `close` fires, socket torn down mid-pipeline. `make_getkq_requests` swallows the resulting `DalliError` (`pipelined_getter.rb:60`), the drain finds nothing on the wire, and `get_multi` returns `{}`. The application sees an empty result and either treats those keys as cache misses (extra DB load + refill churn) or — worse — interprets the empty hash as a definitive "not present" signal.

## The fix

Replace the global-state read with a local flag set at the very end of the begin block:

```ruby
begin
  request_local_completed = false
  @connection_manager.start_request!
  response = send(opkey, *args)
  @connection_manager.finish_request! unless opkey == :pipelined_get
  request_local_completed = true
  response
rescue …
ensure
  close unless request_local_completed
end
```

The local flag is scoped to this method invocation; nothing outside this frame can affect it. The same close-on-abort guarantee from #68 is preserved for non-StandardError exceptions like `Async::Stop`.

Also dropped `require 'English'` from `base.rb` since the file no longer references any of those globals.

## Test

`test/integration/test_fiber_concurrency.rb` grows a third case that:

1. Warms two keys
2. From inside a `rescue StandardError`, calls `dc.get_multi(%w[a b]) { … }` (block form is required to force `:pipelined_get` rather than the single-server-optimized `:read_multi_req`)
3. Asserts the result hash is correct AND `close` was never called

Verified pre/post-fix on `main` head:

- Pre-fix (revert just `lib/dalli/protocol/base.rb`):
  ```
  Failure: expected {"a"=>"val_a","b"=>"val_b"}, got {}
  ```
- Post-fix: passes.

## Test plan
- [x] New test reproduces the bug pre-fix (returns `{}`)
- [x] New test passes post-fix
- [x] Existing fiber cancellation tests from #68 / #69 still pass
- [x] `bundle exec rake test` passes
- [x] `bundle exec rubocop` clean