### PR TITLE
Include full meta protocol error responses

### DIFF
--- a/lib/dalli/protocol/meta/response_processor.rb
+++ b/lib/dalli/protocol/meta/response_processor.rb
@@ -215,13 +215,14 @@ module Dalli
         end
 
         def error_on_unexpected!(expected_codes)
-          tokens = next_line_to_tokens
+          line = read_line
+          tokens = line&.split || []
 
           return tokens if expected_codes.include?(tokens.first)
 
-          raise Dalli::ServerError if tokens.first == SERVER_ERROR
+          raise Dalli::ServerError, line if tokens.first == SERVER_ERROR
 
-          raise Dalli::DalliError, "Response error: #{tokens.first}"
+          raise Dalli::DalliError, "Response error: #{line}"
         end
 
         def meta_flags_from_tokens(tokens)

--- a/test/protocol/meta/test_response_processor.rb
+++ b/test/protocol/meta/test_response_processor.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative '../../helper'
+
+class ResponseProcessorTestIO
+  def initialize(*lines)
+    @lines = lines
+  end
+
+  def read_line
+    @lines.shift&.dup
+  end
+end
+
+describe Dalli::Protocol::Meta::ResponseProcessor do
+  it 'includes the full unexpected response line in DalliError messages' do
+    response_cases = [
+      [
+        # e.g. an unsupported/unknown meta-protocol flag reaches memcached.
+        :meta_set_with_cas,
+        "CLIENT_ERROR invalid flag\r\n",
+        'Response error: CLIENT_ERROR invalid flag'
+      ],
+      [
+        # e.g. a malformed numeric token such as an invalid TTL reaches memcached.
+        :meta_delete,
+        "CLIENT_ERROR bad token in command line format\r\n",
+        'Response error: CLIENT_ERROR bad token in command line format'
+      ],
+      [
+        # e.g. a request uses the base64-key flag but the key is not decodable.
+        :meta_get_with_value,
+        "CLIENT_ERROR error decoding key\r\n",
+        'Response error: CLIENT_ERROR error decoding key'
+      ]
+    ]
+
+    response_cases.each do |method_name, line, expected_message|
+      io = ResponseProcessorTestIO.new(line)
+      processor = Dalli::Protocol::Meta::ResponseProcessor.new(io, nil)
+
+      err = assert_raises(Dalli::DalliError) do
+        processor.public_send(method_name)
+      end
+
+      assert_instance_of Dalli::DalliError, err
+      assert_equal expected_message, err.message
+    end
+  end
+
+  it 'includes the full server error response line in ServerError messages' do
+    response_cases = [
+      # e.g. the serialized/compressed value exceeds memcached's item size limit.
+      "SERVER_ERROR object too large for cache\r\n",
+      # e.g. memcached cannot allocate memory for the item being stored.
+      "SERVER_ERROR out of memory storing object\r\n",
+      # e.g. a proxy/router reports a backend write failure as a server error.
+      "SERVER_ERROR proxy write to backend failed\r\n"
+    ]
+
+    response_cases.each do |line|
+      io = ResponseProcessorTestIO.new(line)
+      processor = Dalli::Protocol::Meta::ResponseProcessor.new(io, nil)
+
+      err = assert_raises(Dalli::ServerError) do
+        processor.meta_set_with_cas
+      end
+
+      assert_equal line.chomp("\r\n"), err.message
+    end
+  end
+end

--- a/test/protocol/meta/test_response_processor.rb
+++ b/test/protocol/meta/test_response_processor.rb
@@ -14,6 +14,10 @@ end
 
 describe Dalli::Protocol::Meta::ResponseProcessor do
   it 'includes the full unexpected response line in DalliError messages' do
+    # Representative CLIENT_ERROR lines returned by memcached. The response
+    # processor treats each as an unexpected response code, but should preserve
+    # the full response line in the raised DalliError.
+
     response_cases = [
       [
         # e.g. an unsupported/unknown meta-protocol flag reaches memcached.


### PR DESCRIPTION
## Summary
- preserve the full unexpected meta-protocol response line in DalliError messages
- add response processor tests covering common CLIENT_ERROR & SERVER_ERROR variants