### PR TITLE
Fix truncated values when the peer closes mid-response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Dalli Changelog
 Unreleased
 ==========
 
+- Ensure fixed-length response reads consume exactly the requested number of
+  bytes or fail. `ConnectionManager#read` / `#read_exact` previously issued a
+  single `IO#read(count)`, which returns a short (truncated) buffer when the
+  peer closes the connection partway through a response body. That truncated
+  buffer was surfaced as a valid (decodable-but-wrong) value. Reads now loop
+  until `count` bytes arrive, and a premature EOF raises so the dirty socket is
+  closed/retried instead of reused. (ianks)
 - Add tombstone (mark-stale) support to `Client#delete` / `delete_cas` /
   `delete_multi` via new `:invalidate`, `:tombstone_ttl`, `:drop_value`
   request-option keys (corresponding to meta-protocol `I`, `T`, `x` flags

--- a/lib/dalli/protocol/connection_manager.rb
+++ b/lib/dalli/protocol/connection_manager.rb
@@ -168,13 +168,13 @@ module Dalli
       end
 
       def read(count)
-        @sock.read(count)
+        read_bytes(count)
       rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
         error_on_request!(e)
       end
 
       def read_exact(count)
-        @sock.read(count)
+        read_bytes(count)
       rescue SystemCallError, *TIMEOUT_ERRORS, EOFError => e
         error_on_request!(e)
       end
@@ -273,6 +273,22 @@ module Dalli
 
         time = Time.now - @down_at
         Dalli.logger.warn { format('%<name>s is back (downtime was %<time>.3f seconds)', name: name, time: time) }
+      end
+
+      private
+
+      # Reads exactly `count` bytes. IO#read(count) on a blocking socket blocks
+      # until it has `count` bytes, accumulating across TCP chunks internally,
+      # and only hands back a shorter (or nil) buffer when the stream hits EOF.
+      # So a short read means the peer closed mid-response: raise EOFError and
+      # let read/read_exact's existing `rescue EOFError` route it through
+      # error_on_request!, which closes the dirty socket for a retry on a fresh
+      # connection (and preserves the $ERROR_INFO context down! relies on).
+      def read_bytes(count)
+        buffer = @sock.read(count)
+        return buffer if buffer && buffer.bytesize == count
+
+        raise EOFError, "EOF reading #{count} bytes; received #{buffer ? buffer.bytesize : 0}"
       end
     end
   end

--- a/test/integration/test_network.rb
+++ b/test/integration/test_network.rb
@@ -62,6 +62,65 @@ describe 'Network' do
         assert_equal 'test_value', dc.get('test_key')
       end
     end
+
+    # A real TCP server truncates the value body of the first get and closes the
+    # socket (as a memcached restart / proxy timeout / reset would), then serves
+    # a full response on the retry. The truncated read must not surface as a
+    # value; the client should raise on the premature EOF and retry.
+    it 'does not return a truncated value when the peer closes mid-response body' do
+      value = 'a' * 512
+      tcp_server = TCPServer.new('127.0.0.1', 0)
+      port = tcp_server.addr[1]
+      get_count = 0
+      get_count_mutex = Mutex.new
+
+      server_thread = Thread.new do
+        loop do
+          conn = tcp_server.accept
+          Thread.new(conn) do |c|
+            while (line = c.gets("\r\n"))
+              cmd, key = line.split
+              case cmd
+              when 'version'
+                c.write("VERSION 1.6.39-fake\r\n")
+              when 'mg'
+                nth = get_count_mutex.synchronize { get_count += 1 }
+                if nth == 1
+                  # Correct header + length, only part of the body, then EOF.
+                  c.write("VA #{value.bytesize} k#{key}\r\n")
+                  c.write(value[0, value.bytesize - 16])
+                  c.close
+                  break
+                else
+                  c.write("VA #{value.bytesize} k#{key}\r\n#{value}\r\n")
+                end
+              else
+                c.write("ERROR\r\n")
+              end
+            end
+          rescue IOError, Errno::ECONNRESET, Errno::EPIPE
+            nil
+          end
+        rescue IOError
+          next
+        end
+      end
+      server_thread.abort_on_exception = true
+
+      begin
+        dc = Dalli::Client.new("127.0.0.1:#{port}", raw: true, socket_timeout: 2, socket_max_failures: 2)
+        conn_mgr = dc.send(:ring).servers.first.instance_variable_get(:@connection_manager)
+
+        assert_equal value, dc.get('trunc_key'),
+                     'a mid-response EOF must not surface a truncated value'
+        assert_equal 2, get_count,
+                     'the truncated first response should trigger a transparent retry'
+        refute_predicate conn_mgr, :request_in_progress?
+      ensure
+        tcp_server.close
+        server_thread.kill
+      end
+    end
   end
 
   it 'opens a standard TCP connection when ssl_context is not configured' do

--- a/test/protocol/test_connection_manager.rb
+++ b/test/protocol/test_connection_manager.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+# IO#read(maxlen) on a blocking socket returns exactly maxlen bytes unless the
+# stream hits EOF, where it returns a shorter (non-nil) buffer or nil. This
+# models that contract deterministically: one queued result per read call, so we
+# can exercise the full read and the premature-EOF cases without a real socket.
+class ContractReadSocket
+  attr_reader :read_calls
+
+  def initialize(*chunks)
+    @chunks = chunks
+    @read_calls = []
+    @closed = false
+  end
+
+  def read(count)
+    @read_calls << count
+    @chunks.shift
+  end
+
+  def close
+    @closed = true
+  end
+
+  def closed?
+    @closed
+  end
+end
+
+describe Dalli::Protocol::ConnectionManager do
+  def connection_manager_with_socket(socket)
+    manager = Dalli::Protocol::ConnectionManager.new(
+      'localhost',
+      11_211,
+      :tcp,
+      socket_failure_delay: nil,
+      socket_max_failures: 2
+    )
+    manager.instance_variable_set(:@sock, socket)
+    manager
+  end
+
+  it 'returns the full buffer from a single read, binary-safe' do
+    socket = ContractReadSocket.new("a\x00\xFFz".b)
+    manager = connection_manager_with_socket(socket)
+
+    result = manager.read_exact(4)
+
+    assert_equal "a\x00\xFFz".b, result
+    assert_equal Encoding::BINARY, result.encoding
+    assert_equal [4], socket.read_calls
+    # #read shares the same fill semantics (both delegate to read_bytes).
+    assert_equal 'xyz', connection_manager_with_socket(ContractReadSocket.new('xyz')).read(3)
+  end
+
+  it 'raises and closes the dirty socket on a premature EOF (nil)' do
+    socket = ContractReadSocket.new(nil)
+    manager = connection_manager_with_socket(socket)
+
+    assert_raises(Dalli::RetryableNetworkError) { manager.read_exact(5) }
+    assert_predicate socket, :closed?
+    refute_predicate manager, :connected?
+  end
+
+  it 'raises and closes the dirty socket on a short read (EOF mid-response)' do
+    socket = ContractReadSocket.new('abc')
+    manager = connection_manager_with_socket(socket)
+
+    assert_raises(Dalli::RetryableNetworkError) { manager.read(5) }
+    assert_predicate socket, :closed?
+  end
+end


### PR DESCRIPTION
Previously, `ConnectionManager#read` / `#read_exact` did a single `@sock.read(count)`. `IO#read(maxlen)` is fread-like: it returns exactly `maxlen` bytes unless the stream hits EOF, in which case it hands back a shorter (non-nil) buffer with no exception. So if the server closes the connection partway through a response body (memcached restart, proxy timeout, connection reset), we'd read a truncated body and surface it as a valid value, a decodable-but-wrong value that then gets returned/cached. This PR fixes that by reading until we have exactly `count` bytes, and raising on a premature EOF so the dirty socket gets closed and retried instead of reused.

The happy path is unchanged and allocation-free: a healthy socket fills `count` in a single read, so we return that buffer directly. Only a short read (the mid-response EOF case) falls through to the accumulation loop.

### How it works

- `read` and `read_exact` both go through a `read_bytes` helper
- fast path: one `@sock.read(count)`, returned directly when it's already the full length
- slow path: loop reading the remainder, and a `nil`/empty chunk before `count` bytes raises, which closes the socket and lets the client retry on a fresh connection

The integration test uses a real TCP server that truncates the first response and closes the socket, then serves the full body on the retry. Before this change it returned the truncated value, now the client transparently retries and gets the right one.