### PR TITLE
Return CacheResult from Client#get_cas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Dalli Changelog
 Unreleased
 ==========
 
+- Change `Client#get_cas` without a block to return a `Dalli::CacheResult`
+  containing `value`, `cas_token`, and the existing status predicates. A miss
+  has `cas_token == 0`; a hit has a positive token. The block form continues
+  yielding `(value, cas_token)`. (drinkbeer)
 - Ensure fixed-length response reads consume exactly the requested number of
   bytes or fail. `ConnectionManager#read` / `#read_exact` previously issued a
   single `IO#read(count)`, which returns a short (truncated) buffer when the

--- a/lib/dalli/cache_result.rb
+++ b/lib/dalli/cache_result.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 module Dalli
-  # Result of a stale-aware read (Client#get_with_status). Always returned —
-  # callers should branch on the predicate methods, not on nil-ness, since a
+  # Result of a status-aware read (Client#get_with_status or Client#get_cas).
+  # Callers should branch on the predicate methods, not on nil-ness, since a
   # tombstoned item has stale? == true with a (possibly empty) value, while
-  # a real cache miss has miss? == true.
+  # a real cache miss has miss? == true. CAS reads also expose an opaque token
+  # through cas_token; other read operations leave it nil.
   class CacheResult
-    attr_reader :value
+    attr_reader :cas_token, :value
 
-    def initialize(value:, stale: false, miss: false)
+    def initialize(value:, stale: false, miss: false, cas_token: nil)
       @value = value
       @stale = stale
       @miss = miss
+      @cas_token = cas_token
       freeze
     end
 

--- a/lib/dalli/client.rb
+++ b/lib/dalli/client.rb
@@ -81,16 +81,17 @@ module Dalli
     end
 
     ##
-    # Get the value and CAS ID associated with the key.  If a block is provided,
-    # value and CAS will be passed to the block.
+    # Get the value and CAS ID associated with the key. Without a block, returns
+    # a Dalli::CacheResult containing the value, status predicates, and CAS token.
+    # If a block is provided, value and CAS will be passed to the block.
     #
     # `req_options` is forwarded to the underlying meta-protocol read so that
     # transport-level options (e.g. `:p_token` / `:l_token`) are applied.
     def get_cas(key, req_options = nil)
-      (value, cas) = perform(:cas, key, req_options)
-      return [value, cas] unless block_given?
+      result = perform(:cas, key, req_options)
+      return result unless block_given?
 
-      yield value, cas
+      yield result.value, result.cas_token
     end
 
     ##
@@ -509,11 +510,12 @@ module Dalli
     end
 
     def cas_core(key, always_set, ttl = nil, req_options = nil)
-      (value, cas) = perform(:cas, key, req_options)
+      result = perform(:cas, key, req_options)
+      value = result.value
       return if value.nil? && !always_set
 
       newvalue = yield(value)
-      perform(:set, key, newvalue, ttl_or_default(ttl), cas, req_options)
+      perform(:set, key, newvalue, ttl_or_default(ttl), result.cas_token, req_options)
     end
 
     ##

--- a/lib/dalli/protocol/meta/response_processor.rb
+++ b/lib/dalli/protocol/meta/response_processor.rb
@@ -42,12 +42,13 @@ module Dalli
 
         def meta_get_with_value_and_cas
           tokens = error_on_unexpected!([VA, EN, HD])
-          return [nil, 0] if tokens.first == EN
+          return ::Dalli::CacheResult.new(value: nil, miss: true, cas_token: 0) if tokens.first == EN
 
           cas = cas_from_tokens(tokens)
-          return [nil, cas] unless tokens.first == VA
+          return ::Dalli::CacheResult.new(value: nil, miss: true, cas_token: cas) unless tokens.first == VA
 
-          [@value_marshaller.retrieve(read_data(tokens[1].to_i), bitflags_from_tokens(tokens)), cas]
+          value = @value_marshaller.retrieve(read_data(tokens[1].to_i), bitflags_from_tokens(tokens))
+          ::Dalli::CacheResult.new(value: value, stale: stale_from_tokens(tokens), cas_token: cas)
         end
 
         def meta_get_with_value_and_meta_flags(cache_nils: false)

--- a/test/integration/test_cas.rb
+++ b/test/integration/test_cas.rb
@@ -5,15 +5,20 @@ require_relative '../helper'
 describe 'CAS behavior' do
   describe 'get_cas' do
     describe 'when no block is given' do
-      it 'returns the value and a CAS' do
+      it 'returns a hit CacheResult with the value and CAS token' do
         memcached_persistent do |dc|
           dc.flush
 
           dc.set('key1', 'abcd')
-          value, cas = dc.get_cas('key1')
+          result = dc.get_cas('key1')
 
-          assert_equal 'abcd', value
-          assert valid_cas?(cas)
+          assert_instance_of Dalli::CacheResult, result
+          assert_equal 'abcd', result.value
+          assert valid_cas?(result.cas_token)
+          assert_predicate result, :hit?
+          refute_predicate result, :miss?
+          refute_predicate result, :stale?
+          assert_predicate result, :frozen?
         end
       end
 
@@ -24,20 +29,72 @@ describe 'CAS behavior' do
           dc.flush
 
           dc.set('key1', 'Not found')
-          value, cas = dc.get_cas('key1')
+          result = dc.get_cas('key1')
 
-          assert_equal 'Not found', value
-          assert valid_cas?(cas)
+          assert_equal 'Not found', result.value
+          assert valid_cas?(result.cas_token)
+          assert_predicate result, :hit?
         end
       end
 
-      it 'returns [nil, 0] on a miss' do
+      it 'returns a miss CacheResult with CAS token zero when the key is absent' do
         memcached_persistent do |dc|
           dc.flush
-          value, cas = dc.get_cas('key1')
+          result = dc.get_cas('key1')
 
-          assert_nil value
-          assert_equal 0, cas
+          assert_instance_of Dalli::CacheResult, result
+          assert_nil result.value
+          assert_equal 0, result.cas_token
+          assert_predicate result, :miss?
+          refute_predicate result, :hit?
+          refute_predicate result, :stale?
+        end
+      end
+
+      it 'returns a hit CacheResult with a positive CAS token for a cached nil' do
+        memcached_persistent do |dc|
+          dc.flush
+
+          dc.set('key1', nil)
+          result = dc.get_cas('key1')
+
+          assert_nil result.value
+          assert valid_cas?(result.cas_token)
+          assert_predicate result, :hit?
+          refute_predicate result, :miss?
+        end
+      end
+
+      it 'returns a stale CacheResult with a positive CAS token for a tombstone' do
+        memcached_persistent do |dc|
+          dc.flush
+
+          dc.set('key1', 'stale-value')
+          dc.delete('key1', invalidate: true, tombstone_ttl: 30)
+          result = dc.get_cas('key1')
+
+          assert_equal 'stale-value', result.value
+          assert valid_cas?(result.cas_token)
+          assert_predicate result, :hit?
+          refute_predicate result, :miss?
+          assert_predicate result, :stale?
+        end
+      end
+
+      it 'returns the same CAS token until the value changes' do
+        memcached_persistent do |dc|
+          dc.flush
+
+          dc.set('key1', 'first-value')
+          first_result = dc.get_cas('key1')
+          second_result = dc.get_cas('key1')
+
+          assert_equal first_result.cas_token, second_result.cas_token
+
+          dc.set('key1', 'second-value')
+          third_result = dc.get_cas('key1')
+
+          refute_equal first_result.cas_token, third_result.cas_token
         end
       end
     end
@@ -197,16 +254,16 @@ describe 'CAS behavior' do
         expected = { 'blah' => 'blerg!' }
         dc.set('some_key', expected)
 
-        value, cas = dc.get_cas('some_key')
+        result = dc.get_cas('some_key')
 
-        assert_equal value, expected
-        assert(!cas.nil? && cas != 0)
+        assert_equal expected, result.value
+        assert valid_cas?(result.cas_token)
 
         # Set operation, first with wrong then with correct CAS
         expected = { 'blah' => 'set succeeded' }
 
-        refute(dc.set_cas('some_key', expected, cas + 1))
-        assert op_addset_succeeds(cas = dc.set_cas('some_key', expected, cas))
+        refute(dc.set_cas('some_key', expected, result.cas_token + 1))
+        assert op_addset_succeeds(cas = dc.set_cas('some_key', expected, result.cas_token))
 
         # Replace operation, first with wrong then with correct CAS
         expected = { 'blah' => 'replace succeeded' }

--- a/test/integration/test_routing_tokens_passthrough.rb
+++ b/test/integration/test_routing_tokens_passthrough.rb
@@ -159,20 +159,17 @@ describe 'routing tokens (p_token / l_token) passthrough' do
   end
 
   describe 'get_cas' do
-    it 'accepts routing tokens and returns [value, cas] (return shape unchanged)' do
+    it 'accepts routing tokens and returns a CacheResult' do
       memcached_persistent do |dc|
         dc.flush
         dc.set('rtk', 'val')
 
         result = dc.get_cas('rtk', ROUTING_OPTS)
 
-        assert_kind_of Array, result
-        assert_equal 2, result.length
-        value, cas = result
-
-        assert_equal 'val', value
-        assert_kind_of Integer, cas
-        refute_equal 0, cas
+        assert_instance_of Dalli::CacheResult, result
+        assert_equal 'val', result.value
+        assert_kind_of Integer, result.cas_token
+        refute_equal 0, result.cas_token
       end
     end
 

--- a/test/integration/test_tombstone.rb
+++ b/test/integration/test_tombstone.rb
@@ -27,6 +27,7 @@ describe 'tombstone (mark-stale) support' do
         assert_predicate result, :hit?
         refute_predicate result, :miss?
         refute_predicate result, :stale?
+        assert_nil result.cas_token
       end
     end
 
@@ -298,7 +299,7 @@ describe 'tombstone (mark-stale) support' do
       memcached_persistent do |dc|
         dc.flush
         dc.set('tk', 'val')
-        cas = dc.get_cas('tk').last
+        cas = dc.get_cas('tk').cas_token
 
         dc.delete_cas('tk', cas, invalidate: true, tombstone_ttl: 30)
 

--- a/test/protocol/meta/test_response_processor.rb
+++ b/test/protocol/meta/test_response_processor.rb
@@ -10,9 +10,62 @@ class ResponseProcessorTestIO
   def read_line
     @lines.shift&.dup
   end
+
+  def read(_size)
+    @lines.shift&.dup
+  end
+end
+
+class ResponseProcessorTestValueMarshaller
+  def retrieve(value, _bitflags)
+    value
+  end
 end
 
 describe Dalli::Protocol::Meta::ResponseProcessor do
+  describe '#meta_get_with_value_and_cas' do
+    it 'returns a stale hit CacheResult with the value and CAS token' do
+      io = ResponseProcessorTestIO.new("VA 5 f0 c42 X\r\n", 'value', "\r\n")
+      marshaller = ResponseProcessorTestValueMarshaller.new
+      processor = Dalli::Protocol::Meta::ResponseProcessor.new(io, marshaller)
+
+      result = processor.meta_get_with_value_and_cas
+
+      assert_instance_of Dalli::CacheResult, result
+      assert_equal 'value', result.value
+      assert_equal 42, result.cas_token
+      assert_predicate result, :hit?
+      refute_predicate result, :miss?
+      assert_predicate result, :stale?
+    end
+
+    it 'returns a miss CacheResult with CAS token zero for an EN response' do
+      io = ResponseProcessorTestIO.new("EN\r\n")
+      processor = Dalli::Protocol::Meta::ResponseProcessor.new(io, nil)
+
+      result = processor.meta_get_with_value_and_cas
+
+      assert_instance_of Dalli::CacheResult, result
+      assert_nil result.value
+      assert_equal 0, result.cas_token
+      assert_predicate result, :miss?
+      refute_predicate result, :hit?
+      refute_predicate result, :stale?
+    end
+
+    it 'returns a miss CacheResult with the response CAS token for an HD response' do
+      io = ResponseProcessorTestIO.new("HD c42\r\n")
+      processor = Dalli::Protocol::Meta::ResponseProcessor.new(io, nil)
+
+      result = processor.meta_get_with_value_and_cas
+
+      assert_nil result.value
+      assert_equal 42, result.cas_token
+      assert_predicate result, :miss?
+      refute_predicate result, :hit?
+    end
+  end
+
   it 'includes the full unexpected response line in DalliError messages' do
     # Representative CLIENT_ERROR lines returned by memcached. The response
     # processor treats each as an unexpected response code, but should preserve


### PR DESCRIPTION
## Summary

- extend `Dalli::CacheResult` with an optional `cas_token`
- return a frozen `CacheResult` from no-block `Client#get_cas`, including hit, miss, and stale state
- preserve the existing block yield contract and the behavior of `cas`, `cas!`, `set_cas`, and `get_multi_cas`

This intentionally changes no-block `get_cas` from `[value, cas_token]` to a result object. Callers should use `result.value` and `result.cas_token`; a true miss has token `0`, while non-CAS status reads leave the token `nil`.

Related (Shopify internal): https://github.com/shop/issues-caching-platform/issues/303

## Validation

- `bundle exec rake` (458 runs, 50,356 assertions)
- `bundle exec rubocop --parallel`